### PR TITLE
feat(api): sort name by provider trust and fix mergable same asso

### DIFF
--- a/packages/api/src/modules/association-name/associationName.service.test.ts
+++ b/packages/api/src/modules/association-name/associationName.service.test.ts
@@ -1,12 +1,11 @@
 import associationNameService from "./associationName.service";
 import associationNameRepository from "./repositories/associationName.repository";
 import { ObjectId } from "mongodb";
-import { resolveObjectURL } from "buffer";
 
 describe("associationName.service", () => {
     describe("getNameFromIdentifier()", () => {
         // @ts-expect-error mock private method
-        const mostRecentMock = jest.spyOn(associationNameService, "_getMostRecentEntity");
+        const mergeEntitiesMock = jest.spyOn(associationNameService, "_mergeEntities");
         const repoMock = jest.spyOn(associationNameRepository, "findAllByIdentifier");
         const IDENTIFIER = "toto";
         const REPO_OUTPUT = [
@@ -23,11 +22,11 @@ describe("associationName.service", () => {
         beforeAll(() => {
             repoMock.mockResolvedValue(REPO_OUTPUT);
             // @ts-expect-error mock
-            mostRecentMock.mockImplementation(jest.fn());
+            mergeEntitiesMock.mockImplementation(jest.fn());
         });
         afterAll(() => {
             repoMock.mockRestore();
-            mostRecentMock.mockRestore();
+            mergeEntitiesMock.mockRestore();
         });
 
         it("should call repo", async () => {
@@ -37,20 +36,20 @@ describe("associationName.service", () => {
 
         it("should call most recent value from repo result", async () => {
             await associationNameService.getNameFromIdentifier(IDENTIFIER);
-            expect(mostRecentMock).toBeCalledWith(REPO_OUTPUT);
+            expect(mergeEntitiesMock).toBeCalledWith(REPO_OUTPUT);
         });
 
         it("should return name most recent result", async () => {
             const expected = "nom d'asso";
             // @ts-expect-error mock
-            mostRecentMock.mockReturnValueOnce({ name: expected });
+            mergeEntitiesMock.mockReturnValueOnce({ name: expected });
             const actual = await associationNameService.getNameFromIdentifier(IDENTIFIER);
             expect(actual).toEqual(expected);
         });
 
         it("should not fail if no name in repo result", async () => {
             // @ts-expect-error mock
-            mostRecentMock.mockReturnValueOnce({});
+            mergeEntitiesMock.mockReturnValueOnce({});
             const actual = await associationNameService.getNameFromIdentifier(IDENTIFIER);
             expect(actual).toEqual(undefined);
         });

--- a/packages/api/src/modules/association-name/associationName.service.ts
+++ b/packages/api/src/modules/association-name/associationName.service.ts
@@ -59,17 +59,18 @@ export class AssociationNameService {
         throw new Error("identifier type is not supported");
     }
 
-    private _mergeEntities(entities: AssociationNameEntity[]): AssociationNameEntity {
-        const bestEntity = entities.sort(
-            (a, b) => {
-                const result = AssociationNameService.PROVIDER_SCORES[b.provider] - AssociationNameService.PROVIDER_SCORES[a.provider];
+    private _mergeEntities(entities: AssociationNameEntity[]): AssociationNameEntity | undefined {
+        if (entities.length == 0) return;
 
-                if (result != 0) return result;
+        const bestEntity = entities.sort((a, b) => {
+            const result =
+                AssociationNameService.PROVIDER_SCORES[b.provider] - AssociationNameService.PROVIDER_SCORES[a.provider];
 
-                // if result is 0 so providers have the same scores so select by date
-                return new Date(b.lastUpdate).getTime() - new Date(a.lastUpdate).getTime();
-            }
-        )[0];
+            if (result != 0) return result;
+
+            // if result is 0 so providers have the same scores so select by date
+            return new Date(b.lastUpdate).getTime() - new Date(a.lastUpdate).getTime();
+        })[0];
 
         return {
             name: bestEntity.name,
@@ -143,7 +144,7 @@ export class AssociationNameService {
         // Above reduce creates duplicates. Removes then by creating a Set
         const uniqueMapsValues = new Set(flattenMapsValues);
 
-        return [...uniqueMapsValues].map(this._mergeEntities);
+        return [...uniqueMapsValues].map(this._mergeEntities) as AssociationNameEntity[];
     }
 
     /***

--- a/packages/api/tests/modules/association-name/associationName.service.test.ts
+++ b/packages/api/tests/modules/association-name/associationName.service.test.ts
@@ -12,11 +12,9 @@ describe("AssociationNameService", () => {
                 "0000000000",
                 "FAKE NAME",
                 LAST_UPDATE,
-                ""
+                null
             );
-            jest.spyOn(associationNameRepository, "findAllStartingWith").mockImplementation(
-                jest.fn().mockResolvedValue([associationNameEntity])
-            );
+            jest.spyOn(associationNameRepository, "findAllStartingWith").mockResolvedValue([associationNameEntity]);
             const expected = [associationNameEntity];
             const actual = await associationNameService.getAllStartingWith(INPUT);
             expect(actual).toEqual(expected);


### PR DESCRIPTION
Closes #826 #1015

J'ai sélectionné le nom du provider en qui on avait le plus confiance, et j'ai également réglé un souci de merge d'array qui n'était plus fait (même si j'étais persuadé que c'estait fait )