### PR TITLE
1097 css not trim

### DIFF
--- a/packages/front/svelte/components/SubventionsVersementsDashboard/SubventionTable/SubventionTable.controller.js
+++ b/packages/front/svelte/components/SubventionsVersementsDashboard/SubventionTable/SubventionTable.controller.js
@@ -26,7 +26,7 @@ export default class SubventionTableController {
     // extract Table data to build CSV
     static extractRows(elements) {
         return elements.map(element =>
-            element.subvention ? Object.values(SubventionsAdapter.toSubvention(element.subvention, false)) : null
+            element.subvention ? Object.values(SubventionsAdapter.toSubvention(element.subvention)) : null
         );
     }
 

--- a/packages/front/svelte/components/Tables/TableCell.svelte
+++ b/packages/front/svelte/components/Tables/TableCell.svelte
@@ -8,19 +8,28 @@
 </script>
 
 <td {colspan} class:primary>
-    <div {style}>
-        <slot />
+    <div class="table-cell-container" {style}>
+        <div class="table-cell-content">
+            <slot />
+        </div>
     </div>
 </td>
 
 <style>
-    div {
+    .table-cell-container {
         display: flex;
         justify-content: var(--justify);
         align-items: center;
         height: 92px;
         max-height: 92px;
+    }
+
+    .table-cell-content {
+        display: -webkit-box;
+        overflow: hidden;
         overflow-wrap: anywhere;
+        -webkit-line-clamp: 4;
+        -webkit-box-orient: vertical;
     }
 
     td {

--- a/packages/front/svelte/components/Tables/TableCell.svelte
+++ b/packages/front/svelte/components/Tables/TableCell.svelte
@@ -2,10 +2,9 @@
     export let primary = false;
     export let colspan = undefined;
     export let position = "start";
-    export let overflow = "hidden";
     let style;
 
-    $: style = `--justify: ${position}; --overflow: ${overflow}`;
+    $: style = `--justify: ${position}`;
 </script>
 
 <td {colspan} class:primary>
@@ -21,7 +20,6 @@
         align-items: center;
         height: 92px;
         max-height: 92px;
-        overflow: var(--overflow);
         overflow-wrap: anywhere;
     }
 

--- a/packages/front/svelte/components/Tables/TableCell.svelte
+++ b/packages/front/svelte/components/Tables/TableCell.svelte
@@ -7,7 +7,7 @@
     $: style = `--justify: ${position}`;
 </script>
 
-<td {colspan} class:primary>
+<td {colspan} class:primary class="fr-p-3v">
     <div class="table-cell-container" {style}>
         <div class="table-cell-content">
             <slot />
@@ -34,7 +34,6 @@
 
     td {
         line-break: anywhere;
-        padding: 12px;
     }
 
     td.primary {

--- a/packages/front/svelte/components/Tables/TableCell.svelte
+++ b/packages/front/svelte/components/Tables/TableCell.svelte
@@ -32,10 +32,6 @@
         -webkit-box-orient: vertical;
     }
 
-    td {
-        line-break: anywhere;
-    }
-
     td.primary {
         color: var(--text-active-blue-france);
         font-weight: 500;

--- a/packages/front/svelte/resources/subventions/subventions.adapter.js
+++ b/packages/front/svelte/resources/subventions/subventions.adapter.js
@@ -1,23 +1,12 @@
 import { ApplicationStatus } from "@api-subventions-asso/dto";
 import { valueOrHyphen, numberToEuro } from "@helpers/dataHelper";
-import { trim } from "@helpers/stringHelper";
 import { capitalizeFirstLetter } from "@helpers/textHelper";
 
 export default class SubventionsAdapter {
-    static MAX_CHAR_SIZE = 63;
-
-    static toSubvention(subvention, trimValue = true) {
-        const sizedTrim = value => (value ? trim(value, this.MAX_CHAR_SIZE) : value);
-
+    static toSubvention(subvention) {
         let dispositif = subvention.dispositif;
         let serviceInstructeur = subvention.service_instructeur;
         let projectName = this._getProjectName(subvention);
-
-        if (trimValue) {
-            dispositif = sizedTrim(dispositif);
-            serviceInstructeur = sizedTrim(serviceInstructeur);
-            projectName = sizedTrim(projectName, this.MAX_CHAR_SIZE);
-        }
 
         return {
             serviceInstructeur: valueOrHyphen(serviceInstructeur),

--- a/packages/front/svelte/resources/subventions/subventions.adapter.test.js
+++ b/packages/front/svelte/resources/subventions/subventions.adapter.test.js
@@ -1,10 +1,6 @@
 import SubventionsAdapter from "./subventions.adapter";
 import * as dataHelper from "@helpers/dataHelper";
 jest.mock("@helpers/dataHelper");
-import * as stringHelper from "@helpers/stringHelper";
-jest.mock("@helpers/stringHelper", () => ({
-    trim: value => value
-}));
 import * as textHelper from "@helpers/textHelper";
 jest.mock("@helpers/textHelper", () => ({
     capitalizeFirstLetter: value => value

--- a/packages/front/svelte/resources/subventions/subventions.adapter.test.js
+++ b/packages/front/svelte/resources/subventions/subventions.adapter.test.js
@@ -1,7 +1,6 @@
 import SubventionsAdapter from "./subventions.adapter";
 import * as dataHelper from "@helpers/dataHelper";
 jest.mock("@helpers/dataHelper");
-import * as textHelper from "@helpers/textHelper";
 jest.mock("@helpers/textHelper", () => ({
     capitalizeFirstLetter: value => value
 }));
@@ -39,7 +38,7 @@ describe("Subventions Adapter", () => {
     });
 
     describe("_getProjectName", () => {
-        it("return concatened names", () => {
+        it("return concatenated names", () => {
             const expected = "A. - B. - C.";
             const actual = SubventionsAdapter._getProjectName(SUBVENTION);
             expect(actual).toEqual(expected);


### PR DESCRIPTION
closes #1097 

J'ai aussi fait [ce commit](https://github.com/betagouv/api-subventions-asso/commit/63d4beb262718c21d2773527cb9f6db791508dc6) que je peux retirer sur la découpe des mots. Pour transformer : 
![image](https://user-images.githubusercontent.com/94919029/228596124-79ed302c-6066-4730-8bcf-b94ce27a537a.png)
en
![image](https://user-images.githubusercontent.com/94919029/228595830-a6435784-1e62-46e0-b05b-12797a47ee08.png)

Ya un peu moins d'info mais je trouve que couper au milieu rend la lecture moins clair. On peut aussi faire un sondage mattermost auprès de tout le monde avant de merge, je pense qu'on peut avoir une réponse rapide sur une question simple comme ça