### PR TITLE
clean older user-reset tokens if a user uses one

### DIFF
--- a/packages/api/src/modules/user/user.service.test.ts
+++ b/packages/api/src/modules/user/user.service.test.ts
@@ -606,7 +606,7 @@ describe("User Service", () => {
 
         it("should remove resetUser", async () => {
             await userService.resetPassword(PASSWORD, RESET_TOKEN);
-            expect(mockedUserResetRepository.remove).toHaveBeenCalledWith(RESET_DOCUMENT);
+            expect(mockedUserResetRepository.removeAllByUserId).toHaveBeenCalledWith(USER_WITHOUT_SECRET._id);
         });
 
         it("should notify USER_ACTIVATED", async () => {

--- a/packages/api/src/modules/user/user.service.ts
+++ b/packages/api/src/modules/user/user.service.ts
@@ -391,7 +391,7 @@ export class UserService {
 
         const hashPassword = await bcrypt.hash(password, 10);
 
-        await userResetRepository.remove(reset);
+        await userResetRepository.removeAllByUserId(user._id);
 
         notifyService.notify(NotificationType.USER_ACTIVATED, { email: user.email });
 


### PR DESCRIPTION
J'ai constaté que les token s'accumulaient si les utilisateurs demandent plusieurs fois, donc j'ai fait cette petite modif qui maintiendra un peu de ménage