### PR TITLE
Step3 substeps poc

### DIFF
--- a/packages/api/src/modules/admin-structure/interfaces/http/AdminStructureController.ts
+++ b/packages/api/src/modules/admin-structure/interfaces/http/AdminStructureController.ts
@@ -1,8 +1,7 @@
 import { Controller, Get, Route, Security, Tags, Response } from "tsoa";
-import { AgentTypeEnum } from "dto";
+import { AdminStructureDto, AgentTypeEnum } from "dto";
 import { HttpErrorInterface } from "../../../../shared/errors/httpErrors/HttpError";
 import adminStructureService from "../../adminStructure.service";
-import AdminStructureEntity from "../../entities/AdminStructureEntity";
 
 @Route("/admin-structures")
 @Security("jwt")
@@ -10,13 +9,13 @@ import AdminStructureEntity from "../../entities/AdminStructureEntity";
 export class AdminStructureController extends Controller {
     /**
      * @summary Renvoie les structures administratives associées à un type d'agent
-     * @returns {AdminStructureEntity[]}
+     * @returns {AdminStructureDto[]}
      */
     @Get("/{agentType}")
     @Response<HttpErrorInterface>(500, "Internal Server Error", {
         message: "Internal Server Error",
     })
-    public async getAdminStructureByAgentType(agentType: string): Promise<AdminStructureEntity[]> {
+    public async getAdminStructureByAgentType(agentType: string): Promise<AdminStructureDto[]> {
         return adminStructureService.getAdminStructureByAgentType(agentType as AgentTypeEnum);
     }
 }

--- a/packages/dto/auth/subscriptionForm/adminStructureDto.ts
+++ b/packages/dto/auth/subscriptionForm/adminStructureDto.ts
@@ -1,0 +1,7 @@
+import { AgentTypeEnum } from "./agentType";
+
+export type AdminStructureDto = {
+    agentType: AgentTypeEnum;
+    territoryScope: string;
+    structure: string;
+};

--- a/packages/dto/auth/subscriptionForm/index.ts
+++ b/packages/dto/auth/subscriptionForm/index.ts
@@ -1,1 +1,2 @@
 export * from "./agentJobType";
+export * from "./agentType";

--- a/packages/dto/auth/subscriptionForm/index.ts
+++ b/packages/dto/auth/subscriptionForm/index.ts
@@ -1,2 +1,3 @@
 export * from "./agentJobType";
 export * from "./agentType";
+export * from "./adminStructureDto"

--- a/packages/dto/index.ts
+++ b/packages/dto/index.ts
@@ -10,7 +10,6 @@ export * from "./auth/ResetPasswordDtoResponse";
 export * from "./auth/SignupDtoResponse";
 export * from "./auth/TokenValidationDtoResponse";
 export * from "./auth/subscriptionForm";
-export * from "./auth/subscriptionForm/agentType";
 export * from "./shared/ProviderValue";
 export * from "./shared/Rna";
 export * from "./shared/Siren";

--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -16,6 +16,7 @@
     },
     "scripts": {
         "dev": "vite dev",
+        "vite:clean": "rm -r node_modules/.vite node_modules/.vitest",
         "start": "node ./build/index.js",
         "build": "vite build -l warn",
         "preview": "vite preview",

--- a/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
+++ b/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
@@ -25,6 +25,7 @@
     export let name = id;
     export let options: { value: string; label: string }[];
     export let label = "";
+    export let placeholder = "";
 
     const listId = `list-${id}`;
     let inputElement: HTMLElement, buttonElement: HTMLElement, listElement: HTMLElement;
@@ -46,6 +47,7 @@
                 {id}
                 class="fr-input"
                 {name}
+                {placeholder}
                 type="text"
                 role="combobox"
                 aria-autocomplete="both"

--- a/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
+++ b/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
@@ -15,7 +15,7 @@
     import { nanoid } from "nanoid";
 
     import "./combobox.css";
-    import { onMount } from "svelte";
+    import { onMount, afterUpdate } from "svelte";
     import Store from "$lib/core/Store";
     import { ComboboxAutocomplete } from "$lib/components/AutocompleteSelect/combobox.js";
 
@@ -33,6 +33,7 @@
     storeValue.subscribe(newV => (value = newV)); // cannot be in controller so that binding works
 
     onMount(() => new ComboboxAutocomplete(inputElement, buttonElement, listElement, storeValue));
+    afterUpdate(() => new ComboboxAutocomplete(inputElement, buttonElement, listElement, storeValue));
 </script>
 
 <div class="combobox combobox-list">

--- a/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
+++ b/packages/front/src/lib/components/AutocompleteSelect/AutocompleteSelect.svelte
@@ -24,7 +24,7 @@
     export let id = nanoid(7);
     export let name = id;
     export let options: { value: string; label: string }[];
-    export const label = "";
+    export let label = "";
 
     const listId = `list-${id}`;
     let inputElement: HTMLElement, buttonElement: HTMLElement, listElement: HTMLElement;

--- a/packages/front/src/lib/components/AutocompleteSelect/combobox.css
+++ b/packages/front/src/lib/components/AutocompleteSelect/combobox.css
@@ -51,6 +51,7 @@ ul[role="listbox"] {
   width: 100%;
   overflow: scroll;
   overflow-x: hidden;
+  z-index: 1;
 }
 
 ul[role="listbox"] li[role="option"] {

--- a/packages/front/src/lib/components/AutocompleteSelect/combobox.js
+++ b/packages/front/src/lib/components/AutocompleteSelect/combobox.js
@@ -186,7 +186,7 @@ export class ComboboxAutocomplete {
 
         for (var i = 0; i < this.allOptions.length; i++) {
             option = this.allOptions[i];
-            if (filter.length === 0 || this.getLowercaseContent(option).indexOf(filter) === 0) {
+            if (filter.length === 0 || this.getLowercaseContent(option).indexOf(filter) !== -1) {
                 this.filteredOptions.push(option);
                 this.listboxNode.appendChild(option);
             }

--- a/packages/front/src/lib/components/MultiStepForm/MultiStepForm.controller.js
+++ b/packages/front/src/lib/components/MultiStepForm/MultiStepForm.controller.js
@@ -1,7 +1,7 @@
-import Store from "$lib/core/Store";
+import Store, { derived } from "$lib/core/Store";
 
 export default class MultiStepFormController {
-    constructor(steps, onSubmit) {
+    constructor(steps, onSubmit, buildContext) {
         this.steps = steps;
         this.onSubmit = onSubmit;
         this.currentStep = new Store({
@@ -17,6 +17,7 @@ export default class MultiStepFormController {
         this.isStepBlocked = new Store(true);
         // create an array of empty object that represent each step values
         this.data = new Store(this.steps.map(() => ({})));
+        this.context = derived(this.data, data => buildContext(data));
     }
 
     /**

--- a/packages/front/src/lib/components/MultiStepForm/MultiStepForm.controller.js
+++ b/packages/front/src/lib/components/MultiStepForm/MultiStepForm.controller.js
@@ -19,10 +19,6 @@ export default class MultiStepFormController {
         this.data = new Store(this.steps.map(() => ({})));
     }
 
-    onDestroy() {
-        this._unsubscribe();
-    }
-
     /**
      * Move in to direction to the "step"
      *

--- a/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
+++ b/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
@@ -60,16 +60,15 @@
                 </Button>
             {/if}
             {#if $currentStep.isLastStep}
-                <Button 
+                <Button
                     htmlType="submit"
                     disabled={$isStepBlocked}
-                    trakerName={`${trackerFormName}.form.step${$currentStep.positionLabel}.submit`}
-                >
+                    trakerName={`${trackerFormName}.form.step${$currentStep.positionLabel}.submit`}>
                     {submitLabel}
                 </Button>
             {:else}
                 <Button
-                    htmlType="submit"
+                    htmlType="button"
                     type="secondary"
                     on:click={() => controller.next()}
                     on:submit={() => controller.next()}

--- a/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
+++ b/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
@@ -1,5 +1,4 @@
 <script>
-    import { onDestroy } from "svelte";
     import MultiStepFormController from "./MultiStepForm.controller";
     import Button from "$lib/dsfr/Button.svelte";
 
@@ -11,9 +10,6 @@
     export let trackerFormName;
 
     const controller = new MultiStepFormController(steps, onSubmit);
-
-    onDestroy(() => controller.onDestroy());
-
     const { currentStep, data, isStepBlocked } = controller;
 </script>
 

--- a/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
+++ b/packages/front/src/lib/components/MultiStepForm/MultiStepForm.svelte
@@ -8,9 +8,11 @@
     export let nextLabel = "Suivant";
     export let previousLabel = "Précédent";
     export let trackerFormName;
+    export let buildContext = () => ({});
 
-    const controller = new MultiStepFormController(steps, onSubmit);
-    const { currentStep, data, isStepBlocked } = controller;
+    const controller = new MultiStepFormController(steps, onSubmit, buildContext);
+
+    const { currentStep, data, isStepBlocked, context } = controller;
 </script>
 
 <div class="fr-grid-row">
@@ -43,6 +45,7 @@
             <svelte:component
                 this={$currentStep.step.component}
                 bind:values={$data[$currentStep.index]}
+                context={$context}
                 on:error={() => controller.blockStep()}
                 on:valid={() => controller.unblockStep()} />
             {#if !$currentStep.isFirstStep}

--- a/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
+++ b/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
@@ -1,8 +1,8 @@
-import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import type { AdminStructureDto, AgentTypeEnum } from "@api-subventions-asso/dto";
 import requestsService from "$lib/services/requests.service";
 
 export class SubscriptionFormPort {
-    async getStructures(agentType: AgentTypeEnum) {
+    async getStructures(agentType: AgentTypeEnum): Promise<AdminStructureDto[]> {
         const path = `admin-structures/${agentType}`;
         const result = await requestsService.get(path);
         return result?.data || [];

--- a/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
+++ b/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
@@ -1,4 +1,4 @@
-import type { AdminStructureDto, AgentTypeEnum } from "@api-subventions-asso/dto";
+import type { AdminStructureDto, AgentTypeEnum } from "dto";
 import requestsService from "$lib/services/requests.service";
 
 export class SubscriptionFormPort {

--- a/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
+++ b/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormPort.ts
@@ -1,0 +1,13 @@
+import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import requestsService from "$lib/services/requests.service";
+
+export class SubscriptionFormPort {
+    async getStructures(agentType: AgentTypeEnum) {
+        const path = `admin-structures/${agentType}`;
+        const result = await requestsService.get(path);
+        return result?.data || [];
+    }
+}
+
+const subscriptionFormPort = new SubscriptionFormPort();
+export default subscriptionFormPort;

--- a/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormService.ts
+++ b/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormService.ts
@@ -1,0 +1,11 @@
+import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import subscriptionFormPort from "$lib/resources/auth/subscriptionForm/subscriptionFormPort";
+
+export class SubscriptionFormService {
+    getStructures(agentType: AgentTypeEnum) {
+        return subscriptionFormPort.getStructures(agentType);
+    }
+}
+
+const subscriptionFormService = new SubscriptionFormService();
+export default subscriptionFormService;

--- a/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormService.ts
+++ b/packages/front/src/lib/resources/auth/subscriptionForm/subscriptionFormService.ts
@@ -1,4 +1,4 @@
-import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import type { AgentTypeEnum } from "dto";
 import subscriptionFormPort from "$lib/resources/auth/subscriptionForm/subscriptionFormPort";
 
 export class SubscriptionFormService {

--- a/packages/front/src/routes/auth/activate/[token]/+page.svelte
+++ b/packages/front/src/routes/auth/activate/[token]/+page.svelte
@@ -24,8 +24,8 @@
 
     <MultiStepForm
         steps={controller.steps}
+        buildContext={controller.buildContext}
         onSubmit={values => controller.onSubmit(values)}
         submitLabel="Valider l'inscription"
-        trackerFormName="activate"    
-    />
+        trackerFormName="activate" />
 {/if}

--- a/packages/front/src/routes/auth/activate/[token]/ActivateAccount.controller.js
+++ b/packages/front/src/routes/auth/activate/[token]/ActivateAccount.controller.js
@@ -18,6 +18,7 @@ export default class ActivateAccountController {
             { name: "Informations sur votre profil", component: AgentTypeStep, alert: CollectedDataAlert },
             { name: "Informations sur votre structure", component: StructureStep },
         ];
+        this.buildContext = values => ({ agentType: values[1].agentType });
     }
 
     async onSubmit(values) {

--- a/packages/front/src/routes/auth/activate/[token]/ActivateAccount.controller.js
+++ b/packages/front/src/routes/auth/activate/[token]/ActivateAccount.controller.js
@@ -20,10 +20,9 @@ export default class ActivateAccountController {
         ];
     }
 
-    onSubmit(values) {
-        return authService.resetPassword(this.token, values.password).then(() => {
-            goToUrl("/auth/login?success=ACCOUNT_ACTIVATED");
-        });
+    async onSubmit(values) {
+        await authService.resetPassword(this.token, values.password);
+        goToUrl("/auth/login?success=ACCOUNT_ACTIVATED");
     }
 
     async init() {

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.controller.ts
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.controller.ts
@@ -1,0 +1,21 @@
+import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import Store from "$lib/core/Store";
+import subscriptionFormService from "$lib/resources/auth/subscriptionForm/subscriptionFormService";
+
+export default class ExampleSubStepController {
+    private options: Store<{ value: string; label: string }[]>;
+
+    constructor() {
+        this.options = new Store([]);
+    }
+
+    async init(agentType: AgentTypeEnum): Promise<void> {
+        const structures = await subscriptionFormService.getStructures(agentType);
+        this.options.set(
+            structures.map(structure => ({
+                label: structure.structure,
+                value: structure.structure,
+            })),
+        );
+    }
+}

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.controller.ts
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.controller.ts
@@ -1,4 +1,4 @@
-import type { AgentTypeEnum } from "@api-subventions-asso/dto";
+import type { AgentTypeEnum } from "dto";
 import Store from "$lib/core/Store";
 import subscriptionFormService from "$lib/resources/auth/subscriptionForm/subscriptionFormService";
 
@@ -10,12 +10,18 @@ export default class ExampleSubStepController {
     }
 
     async init(agentType: AgentTypeEnum): Promise<void> {
-        const structures = await subscriptionFormService.getStructures(agentType);
+        // const structures = await subscriptionFormService.getStructures(agentType);
         this.options.set(
-            structures.map(structure => ({
-                label: structure.structure,
-                value: structure.structure,
-            })),
+            // structures.map(structure => ({
+            //     label: structure.structure,
+            //     value: structure.structure,
+            // })),
+            [
+                {
+                    label: "test",
+                    value: "test",
+                },
+            ],
         );
     }
 }

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.svelte
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/ExampleSubStep/ExampleSubStep.svelte
@@ -1,0 +1,31 @@
+<script>
+    import ExampleSubStepController from "./ExampleSubStep.controller";
+    import Input from "$lib/dsfr/Input.svelte";
+    import AutocompleteSelect from "$lib/components/AutocompleteSelect/AutocompleteSelect.svelte";
+
+    // when we will do validation, the substep will send the conclusion
+    // about allowing to submit in this variable that should be bound by the parent
+    // export let valid
+
+    export let values;
+    // allows the substep to make the calls to the API to fill autocomplete fields
+    // the call is not made by the parent because half substeps don't need it
+    export let agentType;
+
+    const ctrl = new ExampleSubStepController();
+    const { options } = ctrl;
+
+    ctrl.init(agentType);
+</script>
+
+<fieldset class="fr-fieldset">
+    <div class="fr-fieldset__element fr-mt-4v">
+        <Input id="some-input" type="text" label="Je suis un champ libre" bind:value={values.example} />
+    </div>
+</fieldset>
+
+<fieldset class="fr-fieldset">
+    <div class="fr-fieldset__element fr-mt-4v">
+        <AutocompleteSelect options={$options} bind:value={values.structure} label="Structure" />
+    </div>
+</fieldset>

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.test.ts
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.test.ts
@@ -18,8 +18,7 @@ describe("StructureStepController", () => {
 
     describe("constructor", () => {
         it("inits dispatch", () => {
-            const expected = "Result From Dispatch";
-            // @ts-expect-error - mock
+            const expected = vi.fn();
             vi.mocked(Dispatch.getDispatcher).mockReturnValueOnce(expected);
             ctrl = new StructureStepController();
             // @ts-expect-error - mock private

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.test.ts
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.test.ts
@@ -37,7 +37,7 @@ describe("StructureStepController", () => {
         });
 
         describe("validators", () => {
-            it.each`
+            it.skip.each`
                 varName          | emptyValue
                 ${"service"}     | ${""}
                 ${"jobType"}     | ${[]}
@@ -63,11 +63,11 @@ describe("StructureStepController", () => {
                 expect(actual).toBeUndefined();
             });
 
-            it.each`
+            it.skip.each`
                 varName      | correctValue
                 ${"service"} | ${"something"}
                 ${"jobType"} | ${["some1"]}
-            `("filled $varName returns error", ({ varName, correctValue }) => {
+            `("filled $varName returns undefined", ({ varName, correctValue }) => {
                 // @ts-expect-error - test private
                 const actual = ctrl.validators[varName](correctValue);
                 expect(actual).toBeUndefined();

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.ts
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.controller.ts
@@ -8,22 +8,28 @@ type Option = {
     label: string;
 };
 
+interface SubStep {
+    component: typeof SvelteComponent;
+    // valid: boolean
+}
+
 export default class StructureStepController {
     private readonly dispatch: (_: string) => void;
+
     public readonly errors: Store<{ [key: string]: string | undefined }>;
-    private static errorMandatory = "Ce champ est obligatoire";
+    // private static errorMandatory = "Ce champ est obligatoire";
     private readonly dirty: { [key: string]: boolean };
 
     private readonly validators: Record<string, (value: any) => string | undefined> = {
-        service: (text: string) => {
-            if (!text) return StructureStepController.errorMandatory;
-        },
-        jobType: (jobs: string[] | null) => {
-            if (!jobs?.length) return StructureStepController.errorMandatory;
-        },
+        // service: (text: string) => {
+        //     if (!text) return StructureStepController.errorMandatory;
+        // },
+        // jobType: (jobs: string[] | null) => {
+        //     if (!jobs?.length) return StructureStepController.errorMandatory;
+        // },
         phoneNumber: (number: string) => {
-            if (!number) return StructureStepController.errorMandatory;
-            if (!isPhoneNumber(number)) return "Entrez un numéro de téléphone valide";
+            // if (!number) return StructureStepController.errorMandatory;
+            if (number && !isPhoneNumber(number)) return "Entrez un numéro de téléphone valide";
         },
     };
 
@@ -44,6 +50,7 @@ export default class StructureStepController {
         for (const inputName of Object.keys(this.validators)) {
             this.dirty[inputName] = false;
         }
+        this.dispatch("valid") // no required field so default is valid
     }
 
     onUpdate(values: Record<string, unknown>, changedKey: string) {

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
@@ -15,9 +15,6 @@
 </script>
 
 <fieldset class="fr-fieldset">
-    <div class="fr-fieldset__element">
-        <span class="fr-hint-text">Sauf mention contraire, tous les champs sont obligatoires.</span>
-    </div>
     <div class="fr-fieldset__element fr-mt-4v">
         <Input
             id="service-input"
@@ -27,8 +24,7 @@
             bind:value={values.service}
             errorMsg={$errors.service}
             error={$errors.service}
-            on:blur={() => ctrl.onUpdate(values, "service")}
-            required={true} />
+            on:blur={() => ctrl.onUpdate(values, "service")} />
     </div>
     <div class="fr-fieldset__element fr-mb-0 fr-mt-4v">
         <Checkbox
@@ -49,7 +45,6 @@
             bind:value={values.phoneNumber}
             errorMsg={$errors.phoneNumber}
             error={$errors.phoneNumber}
-            on:blur={() => ctrl.onUpdate(values, "phoneNumber")}
-            required={true} />
+            on:blur={() => ctrl.onUpdate(values, "phoneNumber")} />
     </div>
 </fieldset>

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
@@ -17,7 +17,7 @@
 </script>
 
 {#if $subStep}
-    <svelte:component this={$subStep.component} bind:values={values} />
+    <svelte:component this={$subStep.component} bind:values agentType={context.agentType} />
 {/if}
 
 <fieldset class="fr-fieldset">

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/StructureStep.svelte
@@ -8,11 +8,17 @@
         jobType: [],
         phoneNumber: "",
     };
+    export let context = {};
 
-    const ctrl = new StructureStepController(values);
+    const ctrl = new StructureStepController();
+    $: ctrl.onUpdateContext(context);
 
-    const { errors } = ctrl;
+    const { errors, subStep } = ctrl;
 </script>
+
+{#if $subStep}
+    <svelte:component this={$subStep.component} bind:values={values} />
+{/if}
 
 <fieldset class="fr-fieldset">
     <div class="fr-fieldset__element fr-mt-4v">

--- a/packages/front/src/routes/auth/activate/[token]/components/StructureStep/__snapshots__/StructureStep.controller.test.ts.snap
+++ b/packages/front/src/routes/auth/activate/[token]/components/StructureStep/__snapshots__/StructureStep.controller.test.ts.snap
@@ -2,9 +2,7 @@
 
 exports[`StructureStepController > constructor > inits 'dirty' 1`] = `
 {
-  "jobType": false,
   "phoneNumber": false,
-  "service": false,
 }
 `;
 


### PR DESCRIPTION
Plutôt que de mal faire un ticket j'ai préféré faire une structure claire avec un exemple de sous-étape.
Je n'ai pas réussi à trancher l'histoire de comment transmettre les valeurs entre le composant d'étape et le composant de sous-étape.

Cette PR fait des fix à droite à gauche, propose 
- un contexte pour communiquer entre les étapes
- de quoi appeler l'api depuis le front pour remplir les autoCompleteSelect de structures sur certaines sous-étapes
- désactive les champs requis sur l'étape 3

J'ai pas eu le temps de trop tester mais normalement ya plus grand choses à faire à partir de ça pour faire les tickets #1526 et #1528 