### PR TITLE
feat(api): new ds forms

### DIFF
--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesDtoAdapter.test.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesDtoAdapter.test.ts
@@ -31,6 +31,15 @@ describe("DemarchesSimplifieesDtoAdapter", () => {
                                         ],
                                     },
                                 ],
+                                pageInfo: {
+                                    hasPreviousPage: false,
+                                    hasNextPage: false,
+                                    endCursor: "MTM",
+                                },
+                            },
+                            service: {
+                                nom: "Service jeunesse et prévention, Direction des affaires maritimes ",
+                                organisme: "mairie de Mours, préfecture de l'Oise, ministère de la Culture",
                             },
                         },
                     },

--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesDtoAdapter.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesDtoAdapter.ts
@@ -26,6 +26,7 @@ export default class DemarchesSimplifieesDtoAdapter {
                             return acc;
                         }, {}),
                     },
+                    service: dto.data.demarche.service,
                 };
             })
             .filter(entity => entity) as DemarchesSimplifieesDataEntity[];

--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.test.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.test.ts
@@ -74,7 +74,12 @@ describe("DemarchesSimplifieesEntityAdapter", () => {
 
     describe("mapSchema", () => {
         const ENTITY = { before: "a", siret: "SIRET" };
-        const MAPPER = { key: [{ to: "after.nested", from: "before" }] };
+        const MAPPER = {
+            key: [
+                { to: "after.nested", from: "before" },
+                { to: "after.same", value: "toujoursPareil" },
+            ],
+        };
         const KEY = "key";
 
         it("adapts to proper format", () => {
@@ -84,6 +89,7 @@ describe("DemarchesSimplifieesEntityAdapter", () => {
                 Object {
                   "after": Object {
                     "nested": "a",
+                    "same": "toujoursPareil",
                   },
                   "siret": "SIRET",
                 }

--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.ts
@@ -18,6 +18,8 @@ export class DemarchesSimplifieesEntityAdapter {
         const subvention = { siret: entity.siret };
 
         mapper[schemaId].forEach(property => {
+            if (property.value) return lodash.set(subvention, property.to, property.value);
+
             let value = lodash.get(entity, property.from);
             const valueDate = [
                 moment(value, "DD MMMM YYYY", "fr", true).toDate(), // Use moment for read French date

--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/__snapshots__/DemarchesSimplifieesDtoAdapter.test.ts.snap
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/__snapshots__/DemarchesSimplifieesDtoAdapter.test.ts.snap
@@ -21,6 +21,10 @@ Array [
       },
     },
     "demarcheId": 12345,
+    "service": Object {
+      "nom": "Service jeunesse et prévention, Direction des affaires maritimes ",
+      "organisme": "mairie de Mours, préfecture de l'Oise, ministère de la Culture",
+    },
     "siret": "00000000000000",
   },
 ]

--- a/packages/api/src/modules/providers/demarchesSimplifiees/dto/DemarchesSimplifieesDto.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/dto/DemarchesSimplifieesDto.ts
@@ -43,6 +43,10 @@ export default interface DemarchesSimplifieesDto {
                     },
                 ];
             };
+            service: {
+                nom: string;
+                organisme: string;
+            };
         };
     };
 }

--- a/packages/api/src/modules/providers/demarchesSimplifiees/entities/DemarchesSimplifieesDataEntity.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/entities/DemarchesSimplifieesDataEntity.ts
@@ -33,4 +33,8 @@ export default interface DemarchesSimplifieesDataEntity {
         champs: DefaultObject<string>;
         annotations: DefaultObject<string>;
     };
+    service: {
+        nom: string;
+        organisme: string;
+    };
 }

--- a/packages/api/src/modules/providers/demarchesSimplifiees/queries/GetDossiersByDemarcheId.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/queries/GetDossiersByDemarcheId.ts
@@ -42,5 +42,9 @@ export default dedent`query getDemarche($demarcheNumber: Int!) {
                 }
             }
         } 
+        service {
+            nom
+            organisme
+        }
     } 
 }`;

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
@@ -3,7 +3,7 @@
   "schema": [
     {
       "to": "service_instructeur",
-      "value": "DIHAL"
+      "from": "service.organisme"
     },
     {
       "from": "siret",
@@ -12,14 +12,6 @@
     {
       "from": "demande.state",
       "to": "status"
-    },
-    {
-      "from": "demande.champs.Q2hhbXAtMzYzNTA0.value",
-      "to": "contact.email"
-    },
-    {
-      "from": "demande.champs.Q2hhbXAtMzYzNTAz.value",
-      "to": "contact.telephone"
     },
     {
       "from": "demande.champs.Q2hhbXAtMzYzNDkz.value",
@@ -73,7 +65,7 @@
     },
     {
       "to": "service_instructeur",
-      "value": "DIHAL"
+      "from": "service.organisme"
     },
     {
       "to": "dispositif",

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
@@ -1,0 +1,103 @@
+{
+  "demarcheId": 72319,
+  "schema": [
+    {
+      "from": "demande.groupeInstructeur.label",
+      "to": "TODO c'est marqué défaut partout"
+    },
+    {
+      "from": "siret",
+      "to": "siret"
+    },
+    {
+      "from": "demande.state",
+      "to": "status"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTA0.value",
+      "to": "contact.email"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTAz.value",
+      "to": "contact.telephone"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNDkz.value",
+      "to": "actions_proposee[0].intitule"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjcxNjY1Ng==.value",
+      "to": "actions_proposee[0].objectifs"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNDk3.value",
+      "to": "actions_proposee[0].description"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzEzMzI0MQ==.value",
+      "to": "montants.demande"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTIz.value",
+      "to": "montants.total"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjcxNzMwNA==.value",
+      "to": "montants.accorde"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMxMA==.value",
+      "to": "ej"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMxMA==.value",
+      "to": "versementKey"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMwNA==.value",
+      "to": "date_commision"
+    },
+    {
+      "from": "demande.dateDepot",
+      "to": "transmis_le"
+    },
+    {
+      "from": "demande.demarche.title",
+      "to": "dispositif"
+    }
+  ],
+  "commonSchema": [
+    {
+      "to": "siret",
+      "from": "siret"
+    },
+    {
+      "to": "service_instructeur",
+      "from": "TODO"
+    },
+    {
+      "to": "dispositif",
+      "from": "demande.demarche.title"
+    },
+    {
+      "to": "montant_accorde",
+      "from": "demande.annotations.Q2hhbXAtMjcxNzMwNA==.value"
+    },
+    {
+      "to": "montant_demande",
+      "from": "demande.champs.Q2hhbXAtMzEzMzI0MQ==.value"
+    },
+    {
+      "to": "objet",
+      "from": "demande.champs.Q2hhbXAtMzYzNDkz.value"
+    },
+    {
+      "to": "providerStatus",
+      "from": "demande.state"
+    },
+    {
+      "to": "dateTransmitted",
+      "from": "demande.dateDepot"
+    }
+  ]
+}

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-72319-form.json
@@ -2,8 +2,8 @@
   "demarcheId": 72319,
   "schema": [
     {
-      "from": "demande.groupeInstructeur.label",
-      "to": "TODO c'est marqué défaut partout"
+      "to": "service_instructeur",
+      "value": "DIHAL"
     },
     {
       "from": "siret",
@@ -54,7 +54,7 @@
       "to": "versementKey"
     },
     {
-      "from": "demande.annotations.Q2hhbXAtMjY3NDMwNA==.value",
+      "from": "demande.annotations.Q2hhbXAtMjY3NDI3Ng==.value",
       "to": "date_commision"
     },
     {
@@ -62,7 +62,7 @@
       "to": "transmis_le"
     },
     {
-      "from": "demande.demarche.title",
+      "value": "Programme 177 « Hébergement, parcours vers le logement et insertion des personnes vulnérables »",
       "to": "dispositif"
     }
   ],
@@ -73,18 +73,18 @@
     },
     {
       "to": "service_instructeur",
-      "from": "TODO"
+      "value": "DIHAL"
     },
     {
       "to": "dispositif",
-      "from": "demande.demarche.title"
+      "value": "Programme 177 « Hébergement, parcours vers le logement et insertion des personnes vulnérables »"
     },
     {
-      "to": "montant_accorde",
+      "to": "montants.accorde",
       "from": "demande.annotations.Q2hhbXAtMjcxNzMwNA==.value"
     },
     {
-      "to": "montant_demande",
+      "to": "montants.demande",
       "from": "demande.champs.Q2hhbXAtMzEzMzI0MQ==.value"
     },
     {

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
@@ -1,0 +1,103 @@
+{
+  "demarcheId": 73407,
+  "schema": [
+    {
+      "from": "demande.groupeInstructeur.label",
+      "to": "TODO c'est marqué défaut partout"
+    },
+    {
+      "from": "siret",
+      "to": "siret"
+    },
+    {
+      "from": "demande.state",
+      "to": "status"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNDkz.value",
+      "to": "actions_proposee[0].intitule"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzIyNDkxMw==.value",
+      "to": "actions_proposee[0].objectifs"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNDk3.value",
+      "to": "actions_proposee[0].description"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzEzMzI0MQ==.value",
+      "to": "montants.demande"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTIz.value",
+      "to": "montants.total"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjcxNzMwNA==.value",
+      "to": "montants.accorde"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMxMA==.value",
+      "to": "ej"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMxMA==.value",
+      "to": "versementKey"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjY3NDMwNA==.value",
+      "to": "date_commision"
+    },
+    {
+      "from": "demande.dateDepot",
+      "to": "transmis_le"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTIw.value",
+      "to": "date_debut"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMzYzNTIx.value",
+      "to": "date_fin"
+    },
+    {
+      "from": "demande.demarche.title",
+      "to": "dispositif"
+    }
+  ],
+  "commonSchema": [
+    {
+      "to": "siret",
+      "from": "siret"
+    },
+    {
+      "to": "service_instructeur",
+      "from": "TODO"
+    },
+    {
+      "to": "dispositif",
+      "from": "demande.demarche.title"
+    },
+    {
+      "to": "montant_accorde",
+      "from": "demande.annotations.Q2hhbXAtMjcxNzMwNA==.value"
+    },
+    {
+      "to": "montant_demande",
+      "from": "demande.champs.Q2hhbXAtMzEzMzI0MQ==.value"
+    },
+    {
+      "to": "objet",
+      "from": "demande.champs.Q2hhbXAtMzYzNDkz.value"
+    },
+    {
+      "to": "providerStatus",
+      "from": "demande.state"
+    },
+    {
+      "to": "dateTransmitted",
+      "from": "demande.dateDepot"
+    }
+  ]
+}

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
@@ -3,7 +3,7 @@
   "schema": [
     {
       "from": "demande.groupeInstructeur.label",
-      "to": "TODO c'est marqué défaut partout"
+      "value": "DREETS AURA"
     },
     {
       "from": "siret",
@@ -18,7 +18,7 @@
       "to": "actions_proposee[0].intitule"
     },
     {
-      "from": "demande.champs.Q2hhbXAtMzIyNDkxMw==.value",
+      "from": "demande.champs.Q2hhbXAtMjcxNjY1Ng==.value",
       "to": "actions_proposee[0].objectifs"
     },
     {
@@ -46,10 +46,6 @@
       "to": "versementKey"
     },
     {
-      "from": "demande.annotations.Q2hhbXAtMjY3NDMwNA==.value",
-      "to": "date_commision"
-    },
-    {
       "from": "demande.dateDepot",
       "to": "transmis_le"
     },
@@ -62,7 +58,7 @@
       "to": "date_fin"
     },
     {
-      "from": "demande.demarche.title",
+      "value": "Pacte des solidarités Auvergne Rhône Alpes",
       "to": "dispositif"
     }
   ],
@@ -73,11 +69,11 @@
     },
     {
       "to": "service_instructeur",
-      "from": "TODO"
+      "value": "DREETS AURA"
     },
     {
       "to": "dispositif",
-      "from": "demande.demarche.title"
+      "value": "Pacte des solidarités Auvergne Rhône Alpes"
     },
     {
       "to": "montant_accorde",

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-73407-form.json
@@ -2,8 +2,8 @@
   "demarcheId": 73407,
   "schema": [
     {
-      "from": "demande.groupeInstructeur.label",
-      "value": "DREETS AURA"
+      "from": "service.nom",
+      "to": "service_instructeur"
     },
     {
       "from": "siret",
@@ -69,7 +69,7 @@
     },
     {
       "to": "service_instructeur",
-      "value": "DREETS AURA"
+      "from": "service.nom"
     },
     {
       "to": "dispositif",

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-75747-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-75747-form.json
@@ -2,7 +2,7 @@
   "demarcheId": 75747,
   "schema": [
     {
-      "from": "demande.groupeInstructeur.label",
+      "from": "service.nom",
       "to": "service_instructeur"
     },
     {
@@ -38,14 +38,6 @@
       "to": "montants.accorde"
     },
     {
-      "from": "demande.champs.Q2hhbXAtMjMzNzMwNA==.value",
-      "to": "contact.email"
-    },
-    {
-      "from": "demande.champs.Q2hhbXAtMjM2MzM2Nw==.value",
-      "to": "contact.telephone"
-    },
-    {
       "from": "demande.dateDepot",
       "to": "transmis_le"
     },
@@ -69,7 +61,7 @@
     },
     {
       "to": "service_instructeur",
-      "from": "demande.groupeInstructeur.label"
+      "from": "service.nom"
     },
     {
       "to": "dispositif",

--- a/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-75747-form.json
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/schemas/schema-75747-form.json
@@ -1,0 +1,99 @@
+{
+  "demarcheId": 75747,
+  "schema": [
+    {
+      "from": "demande.groupeInstructeur.label",
+      "to": "service_instructeur"
+    },
+    {
+      "from": "siret",
+      "to": "siret"
+    },
+    {
+      "from": "demande.state",
+      "to": "status"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM2MzQwMg==.value",
+      "to": "actions_proposee[0].intitule"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM2MzQwNA==.value",
+      "to": "actions_proposee[0].objectifs"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM0MDQ2Mw==.value",
+      "to": "actions_proposee[0].description"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjUwNjg0MA==.value",
+      "to": "montants.demande"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjUzOTE1Ng==.value",
+      "to": "montants.propose"
+    },
+    {
+      "from": "demande.annotations.Q2hhbXAtMjUzOTIyMA==.value",
+      "to": "montants.accorde"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjMzNzMwNA==.value",
+      "to": "contact.email"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM2MzM2Nw==.value",
+      "to": "contact.telephone"
+    },
+    {
+      "from": "demande.dateDepot",
+      "to": "transmis_le"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM2MzQ5NQ==.value",
+      "to": "date_debut"
+    },
+    {
+      "from": "demande.champs.Q2hhbXAtMjM2MzQ5Ng==.value",
+      "to": "date_fin"
+    },
+    {
+      "from": "demande.demarche.title",
+      "to": "dispositif"
+    }
+  ],
+  "commonSchema": [
+    {
+      "to": "siret",
+      "from": "siret"
+    },
+    {
+      "to": "service_instructeur",
+      "from": "demande.groupeInstructeur.label"
+    },
+    {
+      "to": "dispositif",
+      "from": "demande.demarche.title"
+    },
+    {
+      "to": "montant_accorde",
+      "from": "demande.annotations.Q2hhbXAtMjUzOTIyMA==.value"
+    },
+    {
+      "to": "montant_demande",
+      "from": "demande.champs.Q2hhbXAtMjUwNjg0MA==.value"
+    },
+    {
+      "to": "objet",
+      "from": "demande.champs.Q2hhbXAtMjM2MzQwMg==.value"
+    },
+    {
+      "to": "providerStatus",
+      "from": "demande.state"
+    },
+    {
+      "to": "dateTransmitted",
+      "from": "demande.dateDepot"
+    }
+  ]
+}


### PR DESCRIPTION
closes #1546

En plus des schémas, j'ai eu besoin de :

- permettre de renseigner dans le schéma une valeur fixée à donner à un champ format 
    ```json
    {
        "to": "champChezNous",
        "value": "Valeur à mettre pour tous les dossiers"
    }
    ```

- récupérer de DS l'info du service ayant créé la démarche : j'ai donc modifié la query qu'on leur fait.

D'après Alex, s'il n'y a pas de "groupe instructeur" dans l'interface web mais des "instructeurs" (ie pas en groupe) c'est que le service instructeur correspond au service administrateur de la demande.

Dans le cas contraire (il y a des groupes d'instructeurs et pas des instructeurs individuels) il faudrait mapper notre service instructeur vers le label de "groupeInstructeurs" comme fait sur les trois premières démarches intégrées