### PR TITLE
Fix sentry cron

### DIFF
--- a/packages/api/src/decorators/cronController.decorator.test.ts
+++ b/packages/api/src/decorators/cronController.decorator.test.ts
@@ -1,3 +1,5 @@
+import axios from "axios";
+
 jest.mock("toad-scheduler", () => {
     return {
         AsyncTask: jest.fn(),
@@ -14,6 +16,10 @@ import * as Decorators from "./cronController.decorator";
 
 describe("cronController decorator", () => {
     const SCHEDULE = {};
+    let axiosPostSpy;
+
+    beforeAll(() => (axiosPostSpy = jest.spyOn(axios, "post").mockResolvedValue(undefined)));
+    afterAll(() => axiosPostSpy.mockRestore());
 
     describe("newJob()", () => {
         const JOB = {};
@@ -89,6 +95,11 @@ describe("cronController decorator", () => {
             const consoleErrorSpy = jest.spyOn(global.console, "error");
             errorHandler(CRON_NAME);
             expect(consoleErrorSpy).toHaveBeenCalledWith(expected);
+        });
+
+        it("posts error to mattermost", () => {
+            errorHandler({});
+            expect(axiosPostSpy).toHaveBeenCalled();
         });
     });
 

--- a/packages/api/src/decorators/cronController.decorator.ts
+++ b/packages/api/src/decorators/cronController.decorator.ts
@@ -7,12 +7,23 @@ import {
     SimpleIntervalSchedule,
     Task,
 } from "toad-scheduler";
+import axios from "axios";
 import * as Sentry from "@sentry/node";
+import { ENV } from "../configurations/env.conf";
 
 export const errorHandlerFactory = cronName => {
-    return _error => {
+    return error => {
+        Sentry.captureException(error);
         console.error(`error during cron ${cronName}`);
         console.trace();
+        return axios
+            .post("https://mattermost.incubateur.net/hooks/qefuswbp9fybdjf97yqxo93cqr ", {
+                text: `[${ENV}] Le cron \`${cronName}\` a échoué`,
+                username: "Police du Cron",
+                icon_emoji: "alarm_clock",
+                props: { card: `\`\`\`\n${new Error(error).stack}\n\`\`\`` },
+            })
+            .catch(() => console.error("error sending mattermost log"));
     };
 };
 
@@ -23,7 +34,6 @@ export const newJob = (schedule, JobClass, TaskClass) => {
     return function (target, propertyKey: string, descriptor) {
         if (!target[attributeName]) target[attributeName] = [];
         const cronName = `${target.constructor.name}.${propertyKey}`;
-        const sentryCronSlug = `${target.constructor.name}-${propertyKey}`.toLowerCase();
         let message: string;
 
         const loggedFunction =
@@ -31,54 +41,21 @@ export const newJob = (schedule, JobClass, TaskClass) => {
                 ? () => {
                       message = `cron task started: ${cronName}`;
                       console.log(message);
-                      const checkInId = Sentry.captureCheckIn({
-                          monitorSlug: sentryCronSlug,
-                          status: "in_progress",
+                      Sentry.captureEvent({ level: "info", message });
+                      return descriptor.value().then(() => {
+                          message = `cron task ended successfully: ${cronName}`;
+                          Sentry.captureEvent({ level: "info", message });
+                          console.log(message);
                       });
-                      return descriptor
-                          .value()
-                          .then(() => {
-                              message = `cron task ended successfully: ${cronName}`;
-                              Sentry.captureCheckIn({
-                                  checkInId,
-                                  monitorSlug: sentryCronSlug,
-                                  status: "ok",
-                              });
-                              console.log(message);
-                          })
-                          .catch(e => {
-                              Sentry.captureCheckIn({
-                                  checkInId,
-                                  monitorSlug: sentryCronSlug,
-                                  status: "error",
-                              });
-                              throw e;
-                          });
                   }
                 : () => {
                       message = `cron task started: ${cronName}`;
                       console.log(message);
-                      const checkInId = Sentry.captureCheckIn({
-                          monitorSlug: sentryCronSlug,
-                          status: "in_progress",
-                      });
-                      try {
-                          descriptor.value();
-                      } catch (e) {
-                          Sentry.captureCheckIn({
-                              checkInId,
-                              monitorSlug: sentryCronSlug,
-                              status: "error",
-                          });
-                          throw e;
-                      }
+                      Sentry.captureEvent({ level: "info", message });
+                      descriptor.value();
                       message = `cron task ended successfully: ${cronName}`;
                       console.log(message);
-                      Sentry.captureCheckIn({
-                          checkInId,
-                          monitorSlug: sentryCronSlug,
-                          status: "ok",
-                      });
+                      Sentry.captureEvent({ level: "info", message });
                   };
         const task = new TaskClass(cronName, loggedFunction, errorHandlerFactory(cronName));
         target[attributeName].push(new JobClass(schedule, task, { preventOverrun: true }));

--- a/packages/api/src/decorators/cronController.decorator.ts
+++ b/packages/api/src/decorators/cronController.decorator.ts
@@ -34,6 +34,7 @@ export const newJob = (schedule, JobClass, TaskClass) => {
     return function (target, propertyKey: string, descriptor) {
         if (!target[attributeName]) target[attributeName] = [];
         const cronName = `${target.constructor.name}.${propertyKey}`;
+        const sentryCronSlug = `${target.constructor.name}-${propertyKey}`.toLowerCase();
         let message: string;
 
         const loggedFunction =
@@ -42,19 +43,56 @@ export const newJob = (schedule, JobClass, TaskClass) => {
                       message = `cron task started: ${cronName}`;
                       console.log(message);
                       Sentry.captureEvent({ level: "info", message });
-                      return descriptor.value().then(() => {
-                          message = `cron task ended successfully: ${cronName}`;
-                          Sentry.captureEvent({ level: "info", message });
-                          console.log(message);
+                      const checkInId = Sentry.captureCheckIn({
+                          monitorSlug: sentryCronSlug,
+                          status: "in_progress",
                       });
+                      return descriptor
+                          .value()
+                          .then(() => {
+                              message = `cron task ended successfully: ${cronName}`;
+                              Sentry.captureEvent({ level: "info", message });
+                              Sentry.captureCheckIn({
+                                  checkInId,
+                                  monitorSlug: sentryCronSlug,
+                                  status: "ok",
+                              });
+                              console.log(message);
+                          })
+                          .catch(e => {
+                              Sentry.captureCheckIn({
+                                  checkInId,
+                                  monitorSlug: sentryCronSlug,
+                                  status: "error",
+                              });
+                              throw e;
+                          });
                   }
                 : () => {
                       message = `cron task started: ${cronName}`;
                       console.log(message);
                       Sentry.captureEvent({ level: "info", message });
-                      descriptor.value();
+                      const checkInId = Sentry.captureCheckIn({
+                          monitorSlug: sentryCronSlug,
+                          status: "in_progress",
+                      });
+                      try {
+                          descriptor.value();
+                      } catch (e) {
+                          Sentry.captureCheckIn({
+                              checkInId,
+                              monitorSlug: sentryCronSlug,
+                              status: "error",
+                          });
+                          throw e;
+                      }
                       message = `cron task ended successfully: ${cronName}`;
                       console.log(message);
+                      Sentry.captureCheckIn({
+                          checkInId,
+                          monitorSlug: sentryCronSlug,
+                          status: "ok",
+                      });
                       Sentry.captureEvent({ level: "info", message });
                   };
         const task = new TaskClass(cronName, loggedFunction, errorHandlerFactory(cronName));

--- a/packages/api/src/modules/notify/@types/NotificationDataTypes.ts
+++ b/packages/api/src/modules/notify/@types/NotificationDataTypes.ts
@@ -40,4 +40,8 @@ export interface NotificationDataTypes {
         email: string;
         templateId: number;
     };
+    [NotificationType.FAILED_CRON]: {
+        cronName: string;
+        error: Error;
+    };
 }

--- a/packages/api/src/modules/notify/@types/NotificationType.ts
+++ b/packages/api/src/modules/notify/@types/NotificationType.ts
@@ -8,4 +8,5 @@ export enum NotificationType {
     USER_LOGGED,
     USER_ALREADY_EXIST,
     SIGNUP_BAD_DOMAIN,
+    FAILED_CRON,
 }

--- a/packages/api/src/modules/notify/@types/NotifyOutPipe.ts
+++ b/packages/api/src/modules/notify/@types/NotifyOutPipe.ts
@@ -20,6 +20,7 @@ export interface NotifierMethodType {
     ): Promise<boolean>;
     (type: NotificationType.USER_UPDATED, data: NotificationDataTypes[NotificationType.USER_UPDATED]);
     (type: NotificationType.SIGNUP_BAD_DOMAIN, data: NotificationDataTypes[NotificationType.SIGNUP_BAD_DOMAIN]);
+    (type: NotificationType.FAILED_CRON, data: NotificationDataTypes[NotificationType.FAILED_CRON]);
 }
 
 export interface NotifyOutPipe {

--- a/packages/api/src/modules/notify/outPipes/MattermostNotifyPipe.ts
+++ b/packages/api/src/modules/notify/outPipes/MattermostNotifyPipe.ts
@@ -24,6 +24,8 @@ export class MattermostNotifyPipe implements NotifyOutPipe {
                 return this.userDeleted(data);
             case NotificationType.SIGNUP_BAD_DOMAIN:
                 return this.badEmailDomain(data);
+            case NotificationType.FAILED_CRON:
+                return this.failedCron(data);
             default:
                 return Promise.resolve(false);
         }
@@ -66,6 +68,20 @@ export class MattermostNotifyPipe implements NotifyOutPipe {
             username: "Nom de domaine rejeté",
             icon_emoji: "no_entry",
         });
+    }
+
+    private async failedCron({ cronName, error }) {
+        try {
+            return await this.sendMessage({
+                text: `[${ENV}] Le cron \`${cronName}\` a échoué`,
+                username: "Police du Cron",
+                icon_emoji: "alarm_clock",
+                props: { card: `\`\`\`\n${new Error(error).stack}\n\`\`\`` },
+            });
+        } catch {
+            console.error("error sending mattermost log");
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
J'ai constaté que le suivi des crons par sentry ne fonctionnait pas. Après des recherches je pense vraiment voir bien tout configuré donc je pense que c'est un pb de config du sentry de l'incubateur. La PR remet les suivi qu'on avait avant, en + du suivi spécifique cron en espérant qu'il se mette à marcher