### PR TITLE
fix(api): handle empty establishement in sirenStructureToAssociation

### DIFF
--- a/packages/api/src/modules/providers/apiAsso/adapters/ApiAssoDtoAdapter.test.ts
+++ b/packages/api/src/modules/providers/apiAsso/adapters/ApiAssoDtoAdapter.test.ts
@@ -97,6 +97,17 @@ describe("ApiAssoDtoAdapter", () => {
     });
 
     describe("sirenStructureToAssociation", () => {
+        // @ts-expect-error: protected
+        const originalFormatEstablishementSiret = ApiAssoDtoAdapter.formatEstablishementSiret;
+        const mockedFormatEstablishementSiret = jest
+            .fn()
+            .mockReturnValue(sirenStructureFixture.etablissements.etablissement);
+
+        // @ts-expect-error: protected
+        beforeAll(() => (ApiAssoDtoAdapter.formatEstablishementSiret = mockedFormatEstablishementSiret));
+        // @ts-expect-error: protected
+        afterAll(() => (ApiAssoDtoAdapter.formatEstablishementSiret = originalFormatEstablishementSiret));
+
         it("should transform to association", () => {
             expect(ApiAssoDtoAdapter.sirenStructureToAssociation(sirenStructureFixture)).toMatchSnapshot();
         });
@@ -119,6 +130,31 @@ describe("ApiAssoDtoAdapter", () => {
             const actual = ApiAssoDtoAdapter.apiDateToDate("2022-12-23");
 
             expect(actual).toEqual(new Date(Date.UTC(2022, 11, 23)));
+        });
+    });
+
+    describe("formatEstablishementSiret", () => {
+        it("should return empty array", () => {
+            const expected = [];
+            // @ts-expect-error: protected
+            const actual = ApiAssoDtoAdapter.formatEstablishementSiret(undefined);
+            expect(actual).toEqual(expected);
+        });
+
+        it("should wrap establishment in array", () => {
+            const establishment = {};
+            const expected = [establishment];
+            // @ts-expect-error: protected
+            const actual = ApiAssoDtoAdapter.formatEstablishementSiret(establishment);
+            expect(actual).toEqual(expected);
+        });
+
+        it("should return establishments", () => {
+            const establishments = [{}];
+            const expected = establishments;
+            // @ts-expect-error: protected
+            const actual = ApiAssoDtoAdapter.formatEstablishementSiret(establishments);
+            expect(actual).toEqual(expected);
         });
     });
 });

--- a/packages/api/src/modules/providers/apiAsso/adapters/ApiAssoDtoAdapter.ts
+++ b/packages/api/src/modules/providers/apiAsso/adapters/ApiAssoDtoAdapter.ts
@@ -10,7 +10,7 @@ import {
 } from "../dto/StructureDto";
 import { isValidDate } from "../../../../shared/helpers/DateHelper";
 import { RnaStructureDto } from "../dto/RnaStructureDto";
-import { SirenStructureDto } from "../dto/SirenStructureDto";
+import { SirenStructureDto, SirenStructureEtablissementDto } from "../dto/SirenStructureDto";
 
 export default class ApiAssoDtoAdapter {
     static providerNameRna = "RNA";
@@ -23,15 +23,20 @@ export default class ApiAssoDtoAdapter {
         return new Date(Date.UTC(year, month - 1, day));
     }
 
+    protected static formatEstablishementSiret(
+        establishments: SirenStructureEtablissementDto[] | SirenStructureEtablissementDto | undefined,
+    ) {
+        if (!establishments) return [];
+        return Array.isArray(establishments) ? establishments : [establishments];
+    }
+
     static sirenStructureToAssociation(structure: SirenStructureDto): Association {
         const toPvs = ProviderValueFactory.buildProviderValuesAdapter(
             this.providerNameSiren,
             ApiAssoDtoAdapter.apiDateToDate(structure.identite.date_modif_siren),
         );
 
-        const establishmentSiret = Array.isArray(structure.etablissements.etablissement)
-            ? structure.etablissements.etablissement
-            : [structure.etablissements.etablissement];
+        const establishmentSiret = this.formatEstablishementSiret(structure.etablissements.etablissement);
 
         return {
             denomination_siren: toPvs(structure.identite.nom),

--- a/packages/api/src/modules/providers/apiAsso/dto/SirenStructureDto.ts
+++ b/packages/api/src/modules/providers/apiAsso/dto/SirenStructureDto.ts
@@ -1,4 +1,4 @@
-interface SirenStructureEtablissementDto {
+export interface SirenStructureEtablissementDto {
     actif: boolean;
     adresse: {
         cplt_1?: string;
@@ -62,6 +62,6 @@ export interface SirenStructureDto {
     };
     nbEtabsActifs: number;
     etablissements: {
-        etablissement: SirenStructureEtablissementDto[] | SirenStructureEtablissementDto;
+        etablissement?: SirenStructureEtablissementDto[] | SirenStructureEtablissementDto;
     };
 }

--- a/packages/api/src/modules/providers/apiAsso/dto/StructureDto.ts
+++ b/packages/api/src/modules/providers/apiAsso/dto/StructureDto.ts
@@ -1,4 +1,4 @@
-import { Rna, Siren, Siret } from "dto";
+import { Rna } from "dto";
 
 export interface StructureEtablissementDto {
     id_siret: number;


### PR DESCRIPTION
Est-ce que c'est à faire en hotfix ?

Problème qui survient lors d'appel à `ApiAssoDtoAdapter.sirenStructureToAssociation` pour vérifier avant insertion qu'un versement appartient bien à un asso (hors code Z39) => voir `insertBatchChorusLine` dans `chorus.service`