### PR TITLE
fix(front): don't send credentials to geo.api and clear rna-siren alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.44.5](https://github.com/betagouv/api-subventions-asso/compare/v0.44.4...v0.44.5) (2024-01-26)
+
+### Bug Fixes
+
+-   **front:** clear search duplicate alert ([de9091c](https://github.com/betagouv/api-subventions-asso/commit/de9091c7553b24d34d3ae42b98ee71a8f94153b5))
+-   **front:** don't send credentials to geo.api ([94f6de8](https://github.com/betagouv/api-subventions-asso/commit/94f6de89fcbba8b86935b3b59b0769e3349cc769))
+
 ## [0.44.4](https://github.com/betagouv/api-subventions-asso/compare/v0.43.2...v0.44.4) (2024-01-25)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "packages": ["packages/*"],
-    "version": "0.44.4",
+    "version": "0.44.5",
     "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23553,7 +23553,7 @@
             }
         },
         "packages/front": {
-            "version": "0.44.4",
+            "version": "0.44.5",
             "license": "MIT",
             "dependencies": {
                 "@gouvfr/dsfr": "1.11",

--- a/packages/front/CHANGELOG.md
+++ b/packages/front/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.44.5](https://github.com/betagouv/datasubvention/compare/v0.44.4...v0.44.5) (2024-01-26)
+
+### Bug Fixes
+
+-   **front:** clear search duplicate alert ([de9091c](https://github.com/betagouv/datasubvention/commit/de9091c7553b24d34d3ae42b98ee71a8f94153b5))
+-   **front:** don't send credentials to geo.api ([94f6de8](https://github.com/betagouv/datasubvention/commit/94f6de89fcbba8b86935b3b59b0769e3349cc769))
+
 ## [0.44.4](https://github.com/betagouv/datasubvention/compare/v0.43.2...v0.44.4) (2024-01-25)
 
 ### Bug Fixes

--- a/packages/front/package-lock.json
+++ b/packages/front/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "front",
-    "version": "0.44.4",
+    "version": "0.44.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "front",
-            "version": "0.44.4",
+            "version": "0.44.5",
             "license": "MIT",
             "dependencies": {
                 "dto": "^0.44.0",

--- a/packages/front/package.json
+++ b/packages/front/package.json
@@ -1,6 +1,6 @@
 {
     "name": "front",
-    "version": "0.44.4",
+    "version": "0.44.5",
     "description": "> TODO: description",
     "author": "Victor Serain <victor.serain@epitech.eu>",
     "homepage": "https://github.com/betagouv/api-subventions-asso/tree/main/packages/front#readme",

--- a/packages/front/src/lib/resources/externals/geo/geo.port.ts
+++ b/packages/front/src/lib/resources/externals/geo/geo.port.ts
@@ -5,11 +5,11 @@ export class GeoPort {
     BASE_PATH = "https://geo.api.gouv.fr";
 
     async getRegions(): Promise<GeoRegionDto[]> {
-        return (await requestsService.get(this.BASE_PATH + "/regions")).data;
+        return (await requestsService.get(this.BASE_PATH + "/regions", {}, { withCredentials: false })).data;
     }
 
     async getDepartments(): Promise<GeoDepartementDto[]> {
-        return (await requestsService.get(this.BASE_PATH + "/departements")).data;
+        return (await requestsService.get(this.BASE_PATH + "/departements", {}, { withCredentials: false })).data;
     }
 }
 

--- a/packages/front/src/lib/services/requests.service.js
+++ b/packages/front/src/lib/services/requests.service.js
@@ -38,11 +38,7 @@ class RequestsService {
     }
 
     _sendRequest(type, path, params, data, requestOption = {}) {
-        const axiosOption = {};
-
-        if (requestOption.responseType) {
-            axiosOption.responseType = requestOption.responseType;
-        }
+        const axiosOption = { ...requestOption };
 
         return axios.request({
             withCredentials: true,

--- a/packages/front/src/routes/search/[name]/Search.controller.test.ts
+++ b/packages/front/src/routes/search/[name]/Search.controller.test.ts
@@ -5,7 +5,6 @@ const mockedIdentifierHelper = vi.mocked(IdentifierHelper);
 import associationService from "$lib/resources/associations/association.service";
 vi.mock("$lib/resources/associations/association.service");
 const mockedAssociationService = vi.mocked(associationService);
-import { goto } from "$app/navigation";
 vi.mock("$app/navigation");
 
 describe("SearchController", () => {
@@ -15,10 +14,26 @@ describe("SearchController", () => {
             const RNA_SIREN_1 = { rna: RNA, siren: "SIREN_1" };
             const RNA_SIREN_2 = { rna: RNA, siren: "SIREN_2" };
             const expected = [RNA_SIREN_1.siren, RNA_SIREN_2.siren];
-            mockedAssociationService.search.mockResolvedValue([RNA_SIREN_1, RNA_SIREN_2]);
+            mockedAssociationService.search.mockResolvedValueOnce([RNA_SIREN_1, RNA_SIREN_2]);
             mockedIdentifierHelper.isRna.mockReturnValue(true);
             const controller = new SearchController(RNA);
             await new Promise(process.nextTick);
+            const actual = controller.duplicatesFromIdentifier.value;
+            expect(actual).toEqual(expected);
+            mockedIdentifierHelper.isRna.mockReset();
+        });
+
+        it("should unset duplicate store on second search, with name", async () => {
+            const RNA = "RNA";
+            const RNA_SIREN_1 = { rna: RNA, siren: "SIREN_1" };
+            const RNA_SIREN_2 = { rna: RNA, siren: "SIREN_2" };
+            const expected = null;
+            mockedAssociationService.search.mockResolvedValueOnce([RNA_SIREN_1, RNA_SIREN_2]);
+            mockedIdentifierHelper.isRna.mockReturnValueOnce(true);
+            mockedAssociationService.search.mockResolvedValueOnce([RNA_SIREN_1, RNA_SIREN_2]);
+            const controller = new SearchController(RNA);
+            await new Promise(process.nextTick);
+            controller.fetchAssociationFromName("name");
             const actual = controller.duplicatesFromIdentifier.value;
             expect(actual).toEqual(expected);
         });

--- a/packages/front/src/routes/search/[name]/Search.controller.ts
+++ b/packages/front/src/routes/search/[name]/Search.controller.ts
@@ -32,7 +32,7 @@ export default class SearchController {
                             [association.rna, association.siren].find(identifier => identifier !== name),
                         ),
                     );
-                }
+                } else this.duplicatesFromIdentifier.set(null);
                 this.associations.set(associations);
                 // reload same page to save search in history
                 goto(`/search/${this.inputSearch.value}`, { replaceState: true });


### PR DESCRIPTION
faire un tag de version patch et ne pas squash pour garder l'étiquette
closes #2105 