### PR TITLE
fix(api): return of "liste des dirigeants" documents

### DIFF
--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -58,7 +58,7 @@ export class DocumentsService {
             ),
         );
 
-        return (result.flat() as Document[]).filter(doc => doc.type && doc.type.value !== "LDC"); // skip "Liste des dirigeants" because of political insecurities
+        return (result.flat() as Document[])
     }
 
     private async aggregateDocuments(id: StructureIdentifiers): Promise<(Document | null)[]> {

--- a/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
+++ b/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
@@ -154,7 +154,7 @@ export class ApiAssoService
             "BPA", // budget prévisionnel annuel
             "RCA", // Rapport du commissaire aux compte
             "RAR", // Rapport d'activité
-            "CAP",
+            "CPA", // comptes du dernier exercice clôt
             "Jeunesse et Education Populaire (JEP)",
             "Education nationale",
             "Formation", // L'habilitation d'organisme de formation

--- a/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
+++ b/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
@@ -158,6 +158,10 @@ export class ApiAssoService
             "Jeunesse et Education Populaire (JEP)",
             "Education nationale",
             "Formation", // L'habilitation d'organisme de formation
+            "Service Civique", // agrement service civique
+            "AGR", // arrêté de l'agrement
+            "AFF", // Attestation d’affiliation
+            "PRS", // Projet associatif
         ];
 
         const sortByTimeDepotAsc = (a: StructureDacDocumentDto, b: StructureDacDocumentDto) =>

--- a/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
+++ b/packages/api/src/modules/providers/apiAsso/apiAsso.service.ts
@@ -25,6 +25,7 @@ export class ApiAssoService
     extends ProviderCore
     implements AssociationsProvider, EtablissementProvider, DocumentProvider
 {
+    // API documented in part "contrat d'interface" https://lecompteasso.associations.gouv.fr/lapi-association/
     private requestCache = new CacheData<unknown>(CACHE_TIMES.ONE_DAY);
 
     constructor() {
@@ -124,7 +125,13 @@ export class ApiAssoService
     }
 
     private filterRnaDocuments(documents: StructureRnaDocumentDto[]) {
-        const acceptedType = ["MD", "LDC", "PV", "STC"];
+        const acceptedType = [
+            "MD", // récépissé de modification
+            "CR", //"Récépissé de création"
+            "LDC", // liste des dirigeants
+            "PV", // procès verbal
+            "STC", // statuts
+        ];
 
         const sortByYearAndTimeAsc = (a: StructureRnaDocumentDto, b: StructureRnaDocumentDto) => {
             return parseFloat(`${a.annee}.${a.time}`) - parseFloat(`${b.annee}.${b.time}`);
@@ -143,14 +150,14 @@ export class ApiAssoService
 
     private filterDacDocuments(documents: StructureDacDocumentDto[]) {
         const acceptedType = [
-            "RFA",
-            "BPA",
-            "RCA",
-            "RAR",
+            "RFA", // rapports financier ou moral
+            "BPA", // budget prévisionnel annuel
+            "RCA", // Rapport du commissaire aux compte
+            "RAR", // Rapport d'activité
             "CAP",
             "Jeunesse et Education Populaire (JEP)",
             "Education nationale",
-            "Formation",
+            "Formation", // L'habilitation d'organisme de formation
         ];
 
         const sortByTimeDepotAsc = (a: StructureDacDocumentDto, b: StructureDacDocumentDto) =>
@@ -190,7 +197,9 @@ export class ApiAssoService
                 // When api have one document, it is not an array but a single object
                 documents = [documents];
             } else {
-                const errorMessage = "API-ASSO structure do not contain documents or format is not supported. Structure identifier => " + structureIdentifier;
+                const errorMessage =
+                    "API-ASSO structure do not contain documents or format is not supported. Structure identifier => " +
+                    structureIdentifier;
                 Sentry.captureException(new Error(errorMessage));
                 console.error(errorMessage);
                 return [];

--- a/packages/api/src/modules/providers/dauphin/dauphin.service.ts
+++ b/packages/api/src/modules/providers/dauphin/dauphin.service.ts
@@ -41,7 +41,8 @@ export class DauphinService
      */
 
     isDemandesSubventionsProvider = true;
-    isDocumentProvider = false; // only while we no longer have access
+    isDocumentProvider = false; // only while we no longer have access.
+    // when we do again, be careful to skip "liste des dirigeants" because of political insecurities
 
     // Applications
 

--- a/packages/front/src/lib/resources/documents/documents.service.js
+++ b/packages/front/src/lib/resources/documents/documents.service.js
@@ -1,6 +1,5 @@
 import documentPort from "./documents.port";
 import { DATASUB_URL } from "$env/static/public";
-import authService from "$lib/resources/auth/auth.service";
 
 export class DocumentService {
     getBlob(localDocUrl) {
@@ -12,11 +11,12 @@ export class DocumentService {
             RIB: "RIB",
             "Avis Situation Insee": "Avis de situation (INSEE)",
             MD: "Récépissé de modification",
+            CR: "Récépissé de création",
             LDC: "Liste des dirigeants",
             PV: "Procès verbal",
             STC: "Statuts",
             RAR: "Rapport d'activité",
-            RAF: "Rapport financier",
+            RFA: "Rapport financier",
             BPA: "Budget prévisionnel annuel",
             RCA: "Rapport du commissaire aux compte",
             "Education nationale": `Agrément Education Nationale`,

--- a/packages/front/src/lib/resources/documents/documents.service.js
+++ b/packages/front/src/lib/resources/documents/documents.service.js
@@ -22,6 +22,10 @@ export class DocumentService {
             "Education nationale": `Agrément Education Nationale`,
             "Jeunesse et Education Populaire (JEP)": `Agrément jeunesse et éducation populaire`,
             Formation: "L'habilitation d'organisme de formation",
+            "Service Civique" : "Agrément service civique",
+            "AGR": "Arrêté d'agrément",
+            "AFF": "Attestation d’affiliation",
+            "PRS": "Projet associatif",
         };
 
         const compareLabelledDocs = (docA, docB) => {


### PR DESCRIPTION
La liste des dirigeants qui vient du RNA est considérée comme fiable car relue par le greffe aux associations. Il faudra être vigilants au retour de dauphin et à l'ajout d'autres fournisseurs