### PR TITLE
fix(api): keep in sync brevo last connexion

### DIFF
--- a/packages/api/migrations/20240118094300-add-last-activity-date-on-user.js
+++ b/packages/api/migrations/20240118094300-add-last-activity-date-on-user.js
@@ -1,32 +1,34 @@
 module.exports = {
     async up(db) {
         const collection = db.collection("users");
-        await collection.aggregate([
-            {
-                $lookup: {
-                    from: "log",
-                    let: { userEmail: "$email" },
-                    pipeline: [
-                        { $match: { $expr: { $eq: ["$$userEmail", "$meta.req.user.email"] } } },
-                        { $sort: { timestamp: -1 } },
-                        { $limit: 1 },
-                        { $project: { lastActivityDate: "$timestamp" } },
-                    ],
-                    as: "logs",
+        await collection
+            .aggregate([
+                {
+                    $lookup: {
+                        from: "log",
+                        let: { userEmail: "$email" },
+                        pipeline: [
+                            { $match: { $expr: { $eq: ["$$userEmail", "$meta.req.user.email"] } } },
+                            { $sort: { timestamp: -1 } },
+                            { $limit: 1 },
+                            { $project: { lastActivityDate: "$timestamp" } },
+                        ],
+                        as: "logs",
+                    },
                 },
-            },
-            { $unwind: { path: "$logs", preserveNullAndEmptyArrays: true } },
-            {
-                $addFields: {
-                    lastActivityDate: { $ifNull: ["$logs.lastActivityDate", null] },
+                { $unwind: { path: "$logs", preserveNullAndEmptyArrays: true } },
+                {
+                    $addFields: {
+                        lastActivityDate: { $ifNull: ["$logs.lastActivityDate", null] },
+                    },
                 },
-            },
-            {
-                $project: {
-                    logs: 0,
+                {
+                    $project: {
+                        logs: 0,
+                    },
                 },
-            },
-            { $out: "users" },
-        ]);
+                { $out: "users" },
+            ])
+            .toArray();
     },
 };

--- a/packages/api/migrations/20240207101011-lastActivityDate-reviewed.js
+++ b/packages/api/migrations/20240207101011-lastActivityDate-reviewed.js
@@ -1,0 +1,52 @@
+module.exports = {
+    async up(db) {
+        await db
+            .collection("log")
+            .aggregate([
+                { $group: { _id: "$meta.req.user.email", lastActivityDate: { $max: "$timestamp" } } },
+                { $out: "log-last-activity" },
+            ])
+            .toArray();
+
+        await db
+            .collection("users")
+            .aggregate([
+                {
+                    $lookup: {
+                        from: "log-last-activity",
+                        localField: "email",
+                        foreignField: "_id",
+                        as: "lastActivityLog",
+                    },
+                },
+                { $unwind: { path: "$lastActivityLog", preserveNullAndEmptyArrays: true } },
+                {
+                    $addFields: {
+                        lastActivityDate: {
+                            $ifNull: [
+                                "$lastActivityDate",
+                                {
+                                    $ifNull: [
+                                        "$lastActivityLog.lastActivityDate",
+                                        { $cond: { if: { $eq: ["$active", true] }, then: "$signupAt", else: null } },
+                                    ],
+                                },
+                            ],
+                        },
+                    },
+                },
+                { $project: { lastActivityLog: 0 } },
+                { $out: "users-last-activity" },
+            ])
+            .toArray();
+
+        await db.collection("users-last-activity").createIndex({ email: 1 }, { unique: true });
+        await db.renameCollection("users", "users-save");
+        await db.renameCollection("users-last-activity", "users");
+        await db.dropCollection("logs");
+    },
+
+    async down(db) {
+        await db.dropCollection("log-last-activity");
+    },
+};

--- a/packages/api/src/interfaces/cli/User.cli.ts
+++ b/packages/api/src/interfaces/cli/User.cli.ts
@@ -43,4 +43,8 @@ export default class UserCli {
     async notifyAllUsersInSubTools() {
         await userStatsService.notifyAllUsersInSubTools();
     }
+
+    async updateAllUsersInSubTools() {
+        await userStatsService.updateAllUsersInSubTools();
+    }
 }

--- a/packages/api/src/middlewares/UserActivityMiddleware.ts
+++ b/packages/api/src/middlewares/UserActivityMiddleware.ts
@@ -1,10 +1,9 @@
 import { NextFunction, Response } from "express";
-import { isRequestFromAdmin } from "../shared/helpers/HttpHelper";
 import { IdentifiedRequest } from "../@types";
 import userCrudService from "../modules/user/services/crud/user.crud.service";
 
 export default function UserActivityMiddleware(req: IdentifiedRequest, _res: Response, next: NextFunction) {
-    if (!req.user || isRequestFromAdmin(req)) return next();
+    if (!req.user) return next();
     const user = req.user;
     user.lastActivityDate = new Date();
 

--- a/packages/api/src/modules/notify/@types/NotificationDataTypes.ts
+++ b/packages/api/src/modules/notify/@types/NotificationDataTypes.ts
@@ -42,7 +42,8 @@ export interface NotificationDataTypes {
         email: string;
         date: Date;
     };
-    [NotificationType.USER_UPDATED]: Omit<UserActivationInfoDto, "password"> & FutureUserDto;
+    [NotificationType.USER_UPDATED]: Omit<UserActivationInfoDto, "password"> &
+        FutureUserDto & { lastActivityDate?: Date | null };
     [NotificationType.USER_CONFLICT]: FutureUserDto;
     [NotificationType.SIGNUP_BAD_DOMAIN]: FutureUserDto;
     [NotificationType.TEST_EMAIL]: {

--- a/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.test.ts
+++ b/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.test.ts
@@ -128,6 +128,7 @@ describe("BrevoContactNotifyPipe", () => {
             territorialScope: TerritorialScopeEnum.DEPARTMENTAL,
             lastName: "NOM",
             firstName: "PRENOM",
+            lastActivityDate: new Date("2023-04-06"),
         };
 
         it("should call updateContact()", async () => {

--- a/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
+++ b/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
@@ -9,6 +9,11 @@ import BrevoNotifyPipe from "./BrevoNotifyPipe";
 
 const SENDIND_BLUE_CONTACT_LISTS = [Number(API_SENDINBLUE_CONTACT_LIST)];
 
+/*
+ * COMPTE_ACTIVE does not mean that the account is currently active, only that it has been through firstActivation
+ * specifically, a user that had activated the account then lost they password, would have `active: false` on db
+ * but COMPTE_ACTIVE: true on brevo */
+
 export class BrevoContactNotifyPipe extends BrevoNotifyPipe implements NotifyOutPipe {
     private apiInstance: Brevo.ContactsApi;
 
@@ -218,7 +223,7 @@ export class BrevoContactNotifyPipe extends BrevoNotifyPipe implements NotifyOut
 
         const updateContact = new Brevo.UpdateContact();
         const attributes: Record<string, string | boolean> = buildAttributesObject(data);
-        attributes.COMPTE_ACTIVE = true; // TODO le rendre configurable ?
+        attributes.COMPTE_ACTIVE = true;
         updateContact.attributes = attributes;
         updateContact.listIds = SENDIND_BLUE_CONTACT_LISTS;
         return this.apiInstance

--- a/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
+++ b/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
@@ -231,6 +231,7 @@ export class BrevoContactNotifyPipe extends BrevoNotifyPipe implements NotifyOut
             .then(() => true)
             .catch(error => {
                 Sentry.captureException(error);
+                console.error("error updating contact", { email: data.email, error });
                 return false;
             });
     }

--- a/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
+++ b/packages/api/src/modules/notify/outPipes/BrevoContactNotifyPipe.ts
@@ -187,6 +187,7 @@ export class BrevoContactNotifyPipe extends BrevoNotifyPipe implements NotifyOut
             territorialScope: "ECHELON_COLLECTIVITE",
             lastName: "NOM",
             firstName: "PRENOM",
+            lastActivityDate: "DERNIERE_CONNEXION",
         };
 
         function buildAttributesObject(data) {

--- a/packages/api/src/modules/notify/outPipes/__snapshots__/BrevoContactNotifyPipe.test.ts.snap
+++ b/packages/api/src/modules/notify/outPipes/__snapshots__/BrevoContactNotifyPipe.test.ts.snap
@@ -26,6 +26,7 @@ Array [
       "CATEGORIE": "Agent public d’une collectivité territoriale",
       "COMPETENCE_TERRITORIALE": "Interdépartemental",
       "COMPTE_ACTIVE": true,
+      "DERNIERE_CONNEXION": 2023-04-06T00:00:00.000Z,
       "ECHELON_COLLECTIVITE": "Départemental",
       "ECHELON_TERRITORIAL": "ECHELON_TERRITORIAL",
       "NOM": "NOM",

--- a/packages/api/src/modules/user/services/activation/user.activation.service.test.ts
+++ b/packages/api/src/modules/user/services/activation/user.activation.service.test.ts
@@ -289,10 +289,11 @@ describe("user activation service", () => {
             expect(mockedUserResetRepository.remove).toHaveBeenCalledWith(RESET_DOCUMENT);
         });
 
-        it("should notify USER_ACTIVATED", async () => {
+        it("should notify USER_LOGGED", async () => {
             await userActivationService.resetPassword(PASSWORD, RESET_TOKEN);
-            expect(mockedNotifyService.notify).toHaveBeenCalledWith(NotificationType.USER_ACTIVATED, {
+            expect(mockedNotifyService.notify).toHaveBeenCalledWith(NotificationType.USER_LOGGED, {
                 email: USER_EMAIL,
+                date: expect.any(Date),
             });
         });
 
@@ -304,6 +305,7 @@ describe("user activation service", () => {
                     ...USER_WITHOUT_SECRET,
                     hashPassword: PASSWORD,
                     active: true,
+                    lastActivityDate: expect.any(Date),
                 },
                 true,
             );

--- a/packages/api/src/modules/user/services/activation/user.activation.service.ts
+++ b/packages/api/src/modules/user/services/activation/user.activation.service.ts
@@ -87,8 +87,9 @@ export class UserActivationService {
         const hashPassword = await userAuthService.getHashPassword(password);
 
         await userResetRepository.remove(reset as UserReset);
+        const date = new Date();
 
-        notifyService.notify(NotificationType.USER_ACTIVATED, { email: user.email });
+        notifyService.notify(NotificationType.USER_LOGGED, { email: user.email, date });
 
         const userUpdated = (await userRepository.update(
             {
@@ -96,6 +97,7 @@ export class UserActivationService {
                 hashPassword,
                 active: true,
                 profileToComplete: false,
+                lastActivityDate: date,
             },
             true,
         )) as Omit<UserDbo, "hashPassword">;

--- a/packages/api/src/modules/user/services/profile/user.profile.service.test.ts
+++ b/packages/api/src/modules/user/services/profile/user.profile.service.test.ts
@@ -269,5 +269,12 @@ describe("user profile service", () => {
             const actual = await userProfileService.activate("token", USER_ACTIVATION_INFO);
             expect(actual).toEqual(expected);
         });
+
+        it("sets lastActivityDate", async () => {
+            await userProfileService.activate("token", USER_ACTIVATION_INFO);
+            const actual = jest.mocked(userRepository.update).mock.calls[0][0]?.lastActivityDate;
+
+            expect(actual).toEqual(expect.any(Date));
+        });
     });
 });

--- a/packages/api/src/modules/user/services/profile/user.profile.service.ts
+++ b/packages/api/src/modules/user/services/profile/user.profile.service.ts
@@ -141,6 +141,7 @@ export class UserProfileService {
                 ...safeUserInfo,
                 active: true,
                 profileToComplete: false,
+                lastActivityDate: new Date(),
             },
             true,
         )) as Omit<UserDbo, "hashPassword">;

--- a/packages/api/src/shared/ExecutionSyncStack.test.ts
+++ b/packages/api/src/shared/ExecutionSyncStack.test.ts
@@ -1,4 +1,6 @@
 import ExecutionSyncStack from "./ExecutionSyncStack";
+import { waitPromise } from "./helpers/WaitHelper";
+jest.mock("./helpers/WaitHelper");
 
 describe("ExecutionSyncStack", () => {
     let stack: ExecutionSyncStack<string, string>;
@@ -107,7 +109,7 @@ describe("ExecutionSyncStack", () => {
 
         it("should check if all promise as been resolved", async () => {
             const resolver = jest.fn();
-            // @ts-ignore stackLines is private attribut
+            // @ts-ignore stackLines is private attribute
             stack.stackLines.push(
                 {
                     entity: "hello",
@@ -129,6 +131,34 @@ describe("ExecutionSyncStack", () => {
             await stack.executeOperations();
 
             expect(resolver).toBeCalledTimes(3);
+        });
+
+        it("waits between each task", async () => {
+            const TIME = 10;
+            const timedStack = new ExecutionSyncStack(async entity => entity, TIME);
+            // @ts-ignore stackLines is private attribute
+            timedStack.stackLines.push(
+                {
+                    entity: "hello",
+                    rejecter: jest.fn(),
+                    resolver: jest.fn(),
+                },
+                {
+                    entity: "hello",
+                    rejecter: jest.fn(),
+                    resolver: jest.fn(),
+                },
+                {
+                    entity: "hello",
+                    rejecter: jest.fn(),
+                    resolver: jest.fn(),
+                },
+            );
+            // @ts-ignore executeOperations is private method
+            await timedStack.executeOperations();
+
+            expect(waitPromise).toHaveBeenCalledTimes(3);
+            expect(waitPromise).toHaveBeenLastCalledWith(10);
         });
     });
 });

--- a/packages/api/tests/modules/user/__snapshots__/authentification.spec.ts.snap
+++ b/packages/api/tests/modules/user/__snapshots__/authentification.spec.ts.snap
@@ -12,7 +12,7 @@ Object {
     "expirateDate": Any<String>,
     "token": Any<String>,
   },
-  "lastActivityDate": null,
+  "lastActivityDate": Any<String>,
   "lastName": null,
   "profileToComplete": false,
   "roles": Array [

--- a/packages/api/tests/modules/user/authentification.spec.ts
+++ b/packages/api/tests/modules/user/authentification.spec.ts
@@ -221,6 +221,7 @@ describe("AuthentificationController, /auth", () => {
                         signupAt: expect.any(String),
                         _id: expect.any(String),
                         jwt: { expirateDate: expect.any(String), token: expect.any(String) },
+                        lastActivityDate: expect.any(String),
                     }),
                 );
         });


### PR DESCRIPTION
closes #1976 
necessary so that users are notified correctly by brevo about long-term inactivity before deletion

- homogénéiser les infos : les admins aussi ont `lastActivityUpdate` à jour
- migration pour initialiser `lastActivityUpdate` : ajout de `toArray` pour qu'elle se fasse jusqu'au bout. Mais elle est trop lente, donc nouvelle migration en passant par une collection intermédiaire qui groupe et trie `logs`
- mise à jour de `lastActivityUpdate` à l'activation aussi (requête non authentifiée mais qui connecte l'utilisateur côté front)

BREVO
- mise à jour de `DERNIERE_CONNEXION` lors de l'activation de compte
- resynchronisation avec brevo pour mettre à jour `DERNIERE_CONNEXION` avec file d'attente temporisée pour éviter les 429

(d'ailleurs c'est une file (queue) et pas une pile (stack) mais c'est pas le sujet)