### PR TITLE
feat(api): #2413 extract grants api-side

### DIFF
--- a/packages/api/jest.config.integ.setup.ts
+++ b/packages/api/jest.config.integ.setup.ts
@@ -71,10 +71,6 @@ jest.mock("@getbrevo/brevo", () => {
     };
 });
 
-jest.mock("csv-stringify/sync", () => ({
-    stringify: jest.fn(() => "")
-}))
-
 const g = global as unknown as { app?: Server };
 
 const addBetaGouvEmailDomain = async () => {

--- a/packages/api/src/interfaces/http/Association.http.ts
+++ b/packages/api/src/interfaces/http/Association.http.ts
@@ -15,6 +15,7 @@ import { HttpErrorInterface } from "../../shared/errors/httpErrors/HttpError";
 import associationService from "../../modules/associations/associations.service";
 import grantService from "../../modules/grant/grant.service";
 import { JoinedRawGrant } from "../../modules/grant/@types/rawGrant";
+import grantExtractService from "../../modules/grant/grantExtract.service";
 
 @Route("association")
 @Security("jwt")
@@ -87,7 +88,7 @@ export class AssociationHttp extends Controller {
     @Response<string>("200")
     public async getGrantsExtract(identifier: AssociationIdentifiers): Promise<Readable> {
         const grants = await grantService.getGrants(identifier);
-        const csv = grantService.buildCsv(grants);
+        const csv = grantExtractService.buildCsv(grants);
 
         this.setHeader("Content-Type", "text/csv");
         this.setHeader("Content-Disposition", `inline; filename=${identifier}.csv`);

--- a/packages/api/src/interfaces/http/Association.http.ts
+++ b/packages/api/src/interfaces/http/Association.http.ts
@@ -87,12 +87,10 @@ export class AssociationHttp extends Controller {
     @Produces("text/csv")
     @Response<string>("200")
     public async getGrantsExtract(identifier: AssociationIdentifiers): Promise<Readable> {
-        const grants = await grantService.getGrants(identifier);
-        const csv = grantExtractService.buildCsv(grants);
+        const { csv, fileName } = await grantExtractService.buildCsv(identifier);
 
         this.setHeader("Content-Type", "text/csv");
-        this.setHeader("Content-Disposition", `inline; filename=${identifier}.csv`);
-
+        this.setHeader("Content-Disposition", `inline; filename=${fileName}`);
         const stream = new Readable();
         stream.push(csv);
         stream.push(null);

--- a/packages/api/src/interfaces/http/Etablissement.http.test.ts
+++ b/packages/api/src/interfaces/http/Etablissement.http.test.ts
@@ -2,6 +2,10 @@ import { DemandeSubvention, Etablissement } from "dto";
 import Flux from "../../shared/Flux";
 import etablissementsService from "../../modules/etablissements/etablissements.service";
 import { EtablissementHttp } from "./Etablissement.http";
+import grantExtractService from "../../modules/grant/grantExtract.service";
+import consumers from "stream/consumers";
+
+jest.mock("../../modules/grant/grantExtract.service");
 
 const controller = new EtablissementHttp();
 
@@ -111,6 +115,39 @@ describe("EtablissementHttp", () => {
             const expected = true;
             const actual = await controller.registerExtract(IDENTIFIER);
             expect(actual).toEqual(expected);
+        });
+    });
+
+    describe("getGrantExtract", () => {
+        const CSV = "csv";
+        const FILENAME = "filename";
+
+        beforeAll(() => {
+            jest.mocked(grantExtractService.buildCsv).mockResolvedValue({ csv: CSV, fileName: FILENAME });
+        });
+
+        afterAll(() => {
+            jest.mocked(grantExtractService.buildCsv).mockRestore();
+        });
+
+        it("calls grantExtractService.buildCsv", async () => {
+            await controller.getGrantsExtract(IDENTIFIER);
+            expect(grantExtractService.buildCsv).toHaveBeenCalledWith(IDENTIFIER);
+        });
+
+        it("stream contains csv from service", async () => {
+            const expected = CSV;
+            const streamRes = await controller.getGrantsExtract(IDENTIFIER);
+            const actual = await consumers.text(streamRes);
+            expect(actual).toBe(expected);
+        });
+
+        it("stream contains csv from service", async () => {
+            const expected = "inline; filename=filename";
+            await controller.getGrantsExtract(IDENTIFIER);
+            // @ts-expect-error -- test private
+            const actual = await controller?.headers["Content-Disposition"];
+            expect(actual).toBe(expected);
         });
     });
 });

--- a/packages/api/src/modules/grant/@types/GrantToExtract.ts
+++ b/packages/api/src/modules/grant/@types/GrantToExtract.ts
@@ -1,0 +1,29 @@
+import { ApplicationStatus } from "dto";
+
+export type GrantToExtract = {
+    postalCode?: string;
+    instructor?: string;
+    measure?: string;
+    action?: string;
+    askedAmount?: number;
+    grantedAmount?: number;
+    status?: ApplicationStatus;
+    paidAmount?: number;
+    financialCenter?: string;
+    paymentDate?: string;
+    program?: string;
+};
+
+export enum ExtractHeaderLabel {
+    postalCode = "Code postal demandeur",
+    instructor = "Service instructeur",
+    measure = "Dispositif",
+    action = "Intitulé de l'action",
+    askedAmount = "Montant demandé",
+    grantedAmount = "Montant accordé",
+    status = "Statut de la demande",
+    paidAmount = "Montant versé",
+    financialCenter = "Centre financier du dernier paiement",
+    paymentDate = "Date du paiement dernier paiement",
+    program = "Programme des paiements",
+}

--- a/packages/api/src/modules/grant/@types/GrantToExtract.ts
+++ b/packages/api/src/modules/grant/@types/GrantToExtract.ts
@@ -1,14 +1,23 @@
 import { ApplicationStatus } from "dto";
 
 export type GrantToExtract = {
+    // general part
+    assoName: string;
+    assoRna: string;
+    estabAddress: string;
+
+    // application part
+    exercice: number;
     siret: string;
-    // postalCode?: string; TODO
+    postalCode?: string;
     instructor?: string;
     measure?: string;
     action?: string;
     askedAmount?: number;
     grantedAmount?: number;
     status?: ApplicationStatus;
+
+    // payments part
     paidAmount?: number;
     financialCenter?: string;
     paymentDate?: string;
@@ -16,14 +25,23 @@ export type GrantToExtract = {
 };
 
 export enum ExtractHeaderLabel {
+    // general part
+    assoName = "Nom de l'association",
+    assoRna = "RNA de l'association",
+    estabAddress = "Adresse de l'établissement",
+
+    // application part
+    exercice = "Exercice de la demande",
     siret = "Siret",
-    // postalCode = "Code postal demandeur", TODO
+    postalCode = "Code postal demandeur",
     instructor = "Service instructeur",
     measure = "Dispositif",
     action = "Intitulé de l'action",
     askedAmount = "Montant demandé",
     grantedAmount = "Montant accordé",
     status = "Statut de la demande",
+
+    // payments part
     paidAmount = "Montant versé",
     financialCenter = "Centre financier du dernier paiement",
     paymentDate = "Date du dernier paiement",

--- a/packages/api/src/modules/grant/@types/GrantToExtract.ts
+++ b/packages/api/src/modules/grant/@types/GrantToExtract.ts
@@ -26,6 +26,6 @@ export enum ExtractHeaderLabel {
     status = "Statut de la demande",
     paidAmount = "Montant versé",
     financialCenter = "Centre financier du dernier paiement",
-    paymentDate = "Date du paiement dernier paiement",
+    paymentDate = "Date du dernier paiement",
     program = "Programme des paiements",
 }

--- a/packages/api/src/modules/grant/@types/GrantToExtract.ts
+++ b/packages/api/src/modules/grant/@types/GrantToExtract.ts
@@ -1,7 +1,8 @@
 import { ApplicationStatus } from "dto";
 
 export type GrantToExtract = {
-    postalCode?: string;
+    siret: string;
+    // postalCode?: string; TODO
     instructor?: string;
     measure?: string;
     action?: string;
@@ -15,7 +16,8 @@ export type GrantToExtract = {
 };
 
 export enum ExtractHeaderLabel {
-    postalCode = "Code postal demandeur",
+    siret = "Siret",
+    // postalCode = "Code postal demandeur", TODO
     instructor = "Service instructeur",
     measure = "Dispositif",
     action = "Intitulé de l'action",

--- a/packages/api/src/modules/grant/__snapshots__/grant.adapter.test.ts.snap
+++ b/packages/api/src/modules/grant/__snapshots__/grant.adapter.test.ts.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GrantAdapter grantToExtractLine adapts correctly 1`] = `
+Object {
+  "action": "intituléAction",
+  "askedAmount": 12000,
+  "assoName": "nomRNA",
+  "assoRna": "W000000000",
+  "estabAddress": "adresse",
+  "exercice": 2022,
+  "financialCenter": "centreFinancier3",
+  "grantedAmount": 10000,
+  "instructor": "instructeur",
+  "measure": "dispositif",
+  "paidAmount": 6000,
+  "paymentDate": "2022-03-03",
+  "postalCode": "31170",
+  "program": "aggregated",
+  "siret": "01234567891234",
+  "status": "Accordé",
+}
+`;
+
+exports[`GrantAdapter grantToExtractLine adapts correctly with no application 1`] = `
+Object {
+  "action": undefined,
+  "askedAmount": undefined,
+  "assoName": "nomRNA",
+  "assoRna": "W000000000",
+  "estabAddress": "adresse",
+  "exercice": 2022,
+  "financialCenter": "centreFinancier3",
+  "grantedAmount": undefined,
+  "instructor": undefined,
+  "measure": undefined,
+  "paidAmount": 6000,
+  "paymentDate": "2022-03-03",
+  "postalCode": undefined,
+  "program": "aggregated",
+  "siret": undefined,
+  "status": undefined,
+}
+`;
+
+exports[`GrantAdapter grantToExtractLine adapts correctly with no payment 1`] = `
+Object {
+  "action": "intituléAction",
+  "askedAmount": 12000,
+  "assoName": "nomRNA",
+  "assoRna": "W000000000",
+  "estabAddress": "adresse",
+  "exercice": 2022,
+  "financialCenter": undefined,
+  "grantedAmount": 10000,
+  "instructor": "instructeur",
+  "measure": "dispositif",
+  "paidAmount": undefined,
+  "paymentDate": undefined,
+  "postalCode": "31170",
+  "program": "aggregated",
+  "siret": "01234567891234",
+  "status": "Accordé",
+}
+`;

--- a/packages/api/src/modules/grant/grant.adapter.test.ts
+++ b/packages/api/src/modules/grant/grant.adapter.test.ts
@@ -1,0 +1,230 @@
+import GrantAdapter from "./grant.adapter";
+import {
+    ApplicationStatus,
+    Association,
+    Grant,
+    Payment,
+    ProviderValue,
+    ProviderValues,
+    SimplifiedEtablissement,
+} from "dto";
+import { GrantToExtract } from "./@types/GrantToExtract";
+import paymentService from "../payments/payments.service";
+
+jest.mock("../payments/payments.service");
+
+describe("GrantAdapter", () => {
+    const makePV = <T>(v: T) => ({ value: v } as ProviderValue<T>);
+    const makePVs = <T>(v: T) => [{ value: v }] as ProviderValues<T>;
+
+    describe("findSingleProperty", () => {
+        const PROPERTY = "KEY";
+        const VALUE = "VALUE";
+        const MULTIVALUE = "MULTI";
+        const PAYMENT = { KEY: { value: VALUE } };
+
+        it("if null payment arg returns undefined", () => {
+            // @ts-expect-error -- test private
+            const actual = GrantAdapter.findSingleProperty(null, PROPERTY, MULTIVALUE);
+            expect(actual).toBeUndefined();
+        });
+
+        it("if single value and no adapter, return it", () => {
+            const expected = { value: VALUE };
+            // @ts-expect-error -- test private
+            const actual = GrantAdapter.findSingleProperty([PAYMENT, PAYMENT, PAYMENT], PROPERTY, MULTIVALUE);
+            expect(actual).toEqual(expected);
+        });
+
+        it("if single value and adapter, return adapted value", () => {
+            const expected = "ADAPTED";
+            const ADAPTER = jest.fn(v => expected);
+            // @ts-expect-error -- test private
+            const actual = GrantAdapter.findSingleProperty([PAYMENT, PAYMENT, PAYMENT], PROPERTY, MULTIVALUE, ADAPTER);
+            expect(actual).toBe(expected);
+        });
+
+        it("if several values, return multivalue arg", () => {
+            const expected = MULTIVALUE;
+            // @ts-expect-error -- test private
+            const actual = GrantAdapter.findSingleProperty(
+                // @ts-expect-error -- mock args
+                [{ KEY: { value: "OTHER_VALUE" } }, PAYMENT, PAYMENT],
+                PROPERTY,
+                MULTIVALUE,
+            );
+            expect(actual).toBe(expected);
+        });
+    });
+
+    describe("grantToExtractLine", () => {
+        const SIRET = "01234567891234";
+
+        const PAYMENT = {
+            programme: makePV("codePogramme"),
+            libelleProgramme: makePV("label"),
+            amount: makePV(2000),
+            annee_demande: makePV(2022),
+            dateOperation: makePV(new Date("2022-02-02")),
+            centreFinancier: makePV("centreFinancier2"),
+        } as unknown as Payment;
+
+        const GRANT = {
+            application: {
+                siret: makePV(SIRET),
+                annee_demande: makePV(2022),
+                actions_proposee: [{ intitule: makePV("intituléAction") }],
+                montants: {
+                    demande: makePV(12000),
+                    accorde: makePV(10000),
+                },
+                service_instructeur: makePV("instructeur"),
+                dispositif: makePV("dispositif"),
+                statut_label: makePV(ApplicationStatus.GRANTED),
+            },
+            payments: [
+                PAYMENT,
+                {
+                    ...PAYMENT,
+                    dateOperation: makePV(new Date("2022-01-01")),
+                    centreFinancier: makePV("centreFinancier1"),
+                },
+                {
+                    ...PAYMENT,
+                    dateOperation: makePV(new Date("2022-03-03")),
+                    centreFinancier: makePV("centreFinancier3"),
+                },
+            ] as Payment[],
+        } as Grant;
+
+        const ASSO = {
+            denomination_rna: makePVs("nomRNA"),
+            denomination_siren: makePVs("nomSiren"),
+            rna: makePVs("W000000000"),
+        } as Association;
+
+        const ESTAB_BY_SIRET = {
+            [SIRET]: {
+                siret: makePVs(SIRET),
+                nic: makePVs("1234"),
+                adresse: makePVs({ code_postal: "31170" }),
+            },
+        } as Record<string, SimplifiedEtablissement>;
+
+        let adapted: GrantToExtract;
+        let singlePropMock: jest.SpyInstance;
+        let addressToOneLineStringMock: jest.SpyInstance;
+
+        beforeAll(() => {
+            // @ts-expect-error -- mock
+            singlePropMock = jest.spyOn(GrantAdapter, "findSingleProperty").mockReturnValue("aggregated");
+            // @ts-expect-error -- mock
+            addressToOneLineStringMock = jest.spyOn(GrantAdapter, "addressToOneLineString").mockReturnValue("adresse");
+            jest.mocked(paymentService.getPaymentExercise).mockReturnValue(2022);
+
+            adapted = GrantAdapter.grantToExtractLine(GRANT, ASSO, ESTAB_BY_SIRET);
+        });
+
+        it("adapts correctly", () => {
+            expect(adapted).toMatchSnapshot();
+        });
+
+        it("chooses last financial center", () => {
+            const expected = "centreFinancier3";
+            const actual = adapted.financialCenter;
+            expect(actual).toBe(expected);
+        });
+
+        it("chooses last payment date", () => {
+            const expected = "2022-03-03";
+            const actual = adapted.paymentDate;
+            expect(actual).toBe(expected);
+        });
+
+        it("paidAmount", () => {
+            const expected = 6000;
+            const actual = adapted.paidAmount;
+            expect(actual).toBe(expected);
+        });
+
+        it("calls findSingleProperty for program", () => {
+            GrantAdapter.grantToExtractLine(GRANT, ASSO, ESTAB_BY_SIRET);
+            const expected = "aggregated";
+            const actual = adapted.program;
+            expect(singlePropMock).toHaveBeenCalledWith(
+                GRANT.payments,
+                "programme",
+                "multi-programmes",
+                expect.any(Function),
+            );
+            expect(actual).toBe(expected);
+        });
+
+        it("adapts program in findSingleProperty", () => {
+            GrantAdapter.grantToExtractLine(GRANT, ASSO, ESTAB_BY_SIRET);
+            const adapter = singlePropMock.mock.calls?.[0]?.[3];
+            const expected = "code - libellé";
+            const actual = adapter({ programme: makePV("code"), libelleProgramme: makePV("libellé") });
+            expect(actual).toBe(expected);
+        });
+
+        it("use denomination_siren of no denomination_rna", () => {
+            const expected = "nomSiren";
+            const actual = GrantAdapter.grantToExtractLine(
+                GRANT,
+                { ...ASSO, denomination_rna: undefined },
+                ESTAB_BY_SIRET,
+            ).assoName;
+            expect(actual).toBe(expected);
+        });
+
+        it("gets postalCode", () => {
+            const expected = "31170";
+            const actual = adapted.postalCode;
+            expect(actual).toBe(expected);
+        });
+
+        it("gets formatted address", () => {
+            GrantAdapter.grantToExtractLine(GRANT, ASSO, ESTAB_BY_SIRET);
+            const expected = "adresse";
+            const actual = adapted.estabAddress;
+            expect(addressToOneLineStringMock).toHaveBeenCalledWith({ code_postal: "31170" });
+            expect(actual).toBe(expected);
+        });
+
+        it("does not require payment exercise if info from application", () => {
+            GrantAdapter.grantToExtractLine(GRANT, ASSO, ESTAB_BY_SIRET);
+            expect(paymentService.getPaymentExercise).not.toHaveBeenCalled();
+        });
+
+        it("adapts correctly with no application", () => {
+            const actual = GrantAdapter.grantToExtractLine(
+                { payments: GRANT.payments, application: null },
+                ASSO,
+                ESTAB_BY_SIRET,
+            );
+            expect(actual).toMatchSnapshot();
+        });
+
+        it("gets exercise from paymentService if no application", () => {
+            const expected = 1990;
+            jest.mocked(paymentService.getPaymentExercise).mockReturnValueOnce(expected);
+            const actual = GrantAdapter.grantToExtractLine(
+                { payments: GRANT.payments, application: null },
+                ASSO,
+                ESTAB_BY_SIRET,
+            ).exercice;
+            expect(paymentService.getPaymentExercise).toHaveBeenCalledWith(GRANT.payments?.[0]);
+            expect(actual).toBe(expected);
+        });
+
+        it("adapts correctly with no payment", () => {
+            const actual = GrantAdapter.grantToExtractLine(
+                { application: GRANT.application, payments: null },
+                ASSO,
+                ESTAB_BY_SIRET,
+            );
+            expect(actual).toMatchSnapshot();
+        });
+    });
+});

--- a/packages/api/src/modules/grant/grant.adapter.ts
+++ b/packages/api/src/modules/grant/grant.adapter.ts
@@ -1,4 +1,5 @@
-import { ChorusPayment, Grant, Payment } from "dto";
+import { Association, ChorusPayment, FonjepPayment, Grant, Payment, SimplifiedEtablissement } from "dto";
+import paymentService from "../payments/payments.service";
 import { GrantToExtract } from "./@types/GrantToExtract";
 
 const getValue = v => v?.value;
@@ -19,7 +20,11 @@ export default class GrantAdapter {
             : undefined;
     }
 
-    static grantToCsv(grant: Grant): GrantToExtract {
+    static grantToCsv(
+        grant: Grant,
+        asso: Association,
+        estabBySiret: Record<string, SimplifiedEtablissement>,
+    ): GrantToExtract {
         const lastPayment = grant.payments?.sort(
             (p1, p2) => p2.dateOperation.value.getTime() - p1.dateOperation.value.getTime(),
         )?.[0];
@@ -43,17 +48,27 @@ export default class GrantAdapter {
                 0,
             ),
             paymentDate: lastPayment?.dateOperation?.value.toISOString().split("T")[0],
+            joinKey: grant.payments?.[0]?.versementKey?.value ?? grant.application?.versementKey?.value,
         };
 
+        const siret = getValue(grant?.application?.siret);
         return {
+            // general part
+            assoName: getValue(asso.denomination_rna?.[0]) ?? getValue(asso.denomination_siren?.[0]) ?? "",
+            assoRna: getValue(asso.rna?.[0]) ?? "",
+            estabAddress: getValue(estabBySiret[siret].adresse?.[0]),
+
             // application part
+            exercice:
+                grant?.application?.annee_demande?.value ??
+                paymentService.getPaymentExercise((grant?.payments as Payment[])[0]),
             action: getValue(grant?.application?.actions_proposee?.[0]?.intitule),
             askedAmount: getValue(grant?.application?.montants?.demande),
             grantedAmount: getValue(grant?.application?.montants?.accorde),
             instructor: getValue(grant?.application?.service_instructeur),
             measure: getValue(grant?.application?.dispositif),
-            siret: getValue(grant?.application?.siret),
-            // postalCode: getValue(grant?.application?.siret), // TODO siret to code postal
+            siret,
+            postalCode: estabBySiret[siret].adresse?.[0]?.value?.code_postal, // TODO siret to code postal
             status: getValue(grant?.application?.statut_label),
 
             // payment part

--- a/packages/api/src/modules/grant/grant.adapter.ts
+++ b/packages/api/src/modules/grant/grant.adapter.ts
@@ -1,0 +1,62 @@
+import { ChorusPayment, Grant, Payment } from "dto";
+import { GrantToExtract } from "./@types/GrantToExtract";
+
+const getValue = v => v?.value;
+
+export default class GrantAdapter {
+    private static findSingleProperty<T = string>(
+        payments: Payment[] | null,
+        property: string,
+        multiValue: T,
+        adapter?: (v: Payment) => T,
+    ) {
+        if (!adapter) adapter = (v: Payment) => v[property];
+        const values = new Set(payments?.map(versement => versement[property].value));
+        return values.size > 1
+            ? multiValue
+            : payments?.length
+            ? adapter(payments[0]) //
+            : undefined;
+    }
+
+    static grantToCsv(grant: Grant): GrantToExtract {
+        const lastPayment = grant.payments?.sort(
+            (p1, p2) => p2.dateOperation.value.getTime() - p1.dateOperation.value.getTime(),
+        )?.[0];
+
+        const aggregatedPayment = {
+            program: GrantAdapter.findSingleProperty(
+                grant?.payments,
+                "programme",
+                "multi-programmes",
+                p => `${getValue(p.programme)} - ${getValue(p.libelleProgramme)}`,
+            ),
+            // financialCenter: GrantAdapter.findSingleProperty(
+            //     grant?.payments,
+            //     "centreFinancier",
+            //     "multi-centres financiers",
+            //     p => getValue((p as ChorusPayment).centreFinancier),
+            // ), // TODO choose between this and last payment below
+            financialCenter: (lastPayment as ChorusPayment)?.centreFinancier?.value,
+            paidAmount: grant.payments?.reduce(
+                (currentSum: number, payment) => getValue(payment.amount) + currentSum,
+                0,
+            ),
+            paymentDate: lastPayment?.dateOperation?.value.toISOString().split("T")[0],
+        };
+
+        return {
+            // application part
+            action: getValue(grant?.application?.actions_proposee?.[0]?.intitule),
+            askedAmount: getValue(grant?.application?.montants?.demande),
+            grantedAmount: getValue(grant?.application?.montants?.accorde),
+            instructor: getValue(grant?.application?.service_instructeur),
+            measure: getValue(grant?.application?.dispositif),
+            postalCode: getValue(grant?.application?.siret), // TODO siret to code postal
+            status: getValue(grant?.application?.statut_label),
+
+            // payment part
+            ...aggregatedPayment,
+        };
+    }
+}

--- a/packages/api/src/modules/grant/grant.adapter.ts
+++ b/packages/api/src/modules/grant/grant.adapter.ts
@@ -52,7 +52,8 @@ export default class GrantAdapter {
             grantedAmount: getValue(grant?.application?.montants?.accorde),
             instructor: getValue(grant?.application?.service_instructeur),
             measure: getValue(grant?.application?.dispositif),
-            postalCode: getValue(grant?.application?.siret), // TODO siret to code postal
+            siret: getValue(grant?.application?.siret),
+            // postalCode: getValue(grant?.application?.siret), // TODO siret to code postal
             status: getValue(grant?.application?.statut_label),
 
             // payment part

--- a/packages/api/src/modules/grant/grant.adapter.ts
+++ b/packages/api/src/modules/grant/grant.adapter.ts
@@ -20,7 +20,7 @@ export default class GrantAdapter {
             : undefined;
     }
 
-    static grantToCsv(
+    static grantToExtractLines(
         grant: Grant,
         asso: Association,
         estabBySiret: Record<string, SimplifiedEtablissement>,

--- a/packages/api/src/modules/grant/grant.adapter.ts
+++ b/packages/api/src/modules/grant/grant.adapter.ts
@@ -13,11 +13,7 @@ export default class GrantAdapter {
     ) {
         if (!adapter) adapter = (v: Payment) => v[property];
         const values = new Set(payments?.map(versement => versement[property].value));
-        return values.size > 1
-            ? multiValue
-            : payments?.length
-            ? adapter(payments[0]) //
-            : undefined;
+        return values.size > 1 ? multiValue : payments?.length ? adapter(payments[0]) : undefined;
     }
 
     private static addressToOneLineString(address) {
@@ -25,8 +21,7 @@ export default class GrantAdapter {
         const { numero, type_voie, voie, code_postal, commune } = address;
         return [numero, type_voie, voie, code_postal, commune]
             .filter(str => str)
-            .map(str => String(str))
-            .map(str => str.toUpperCase())
+            .map(str => String(str).toUpperCase())
             .join(" ");
     }
 
@@ -52,7 +47,7 @@ export default class GrantAdapter {
                  "centreFinancier",
                  "multi-centres financiers",
                  p => getValue((p as ChorusPayment).centreFinancier),
-             ), // TODO choose between this and last payment below
+             ), // We do what we do te be iso with front implementation but I keep this because it seems more true
             */
             financialCenter: (lastPayment as ChorusPayment)?.centreFinancier?.value,
             paidAmount: grant.payments?.reduce(

--- a/packages/api/src/modules/grant/grant.service.test.ts
+++ b/packages/api/src/modules/grant/grant.service.test.ts
@@ -4,7 +4,6 @@ import { StructureIdentifiersEnum } from "../../@enums/StructureIdentifiersEnum"
 import { isSiret } from "../../shared/Validators";
 import commonGrantService from "./commonGrant.service";
 import mocked = jest.mocked;
-import { siretToSiren } from "../../shared/helpers/SirenHelper";
 import associationsService from "../associations/associations.service";
 import rnaSirenService from "../rna-siren/rnaSiren.service";
 import RnaSirenEntity from "../../entities/RnaSirenEntity";
@@ -15,11 +14,9 @@ import {
     fullGrantProvidersFixtures,
     paymentProvidersFixtures,
 } from "../providers/__fixtures__/providers.fixture";
-import providers, * as ProvidersIndex from "../providers";
-import * as ProviderMock from "../providers/__mocks__";
+import * as ProvidersIndex from "../providers";
 import scdlService from "../providers/scdl/scdl.service";
 import scdlGrantService from "../providers/scdl/scdl.grant.service";
-import { application } from "express";
 import { DemandeSubvention, Grant, Payment } from "dto";
 import { SIRET } from "../../../tests/__fixtures__/association.fixture";
 jest.mock("../providers/scdl/scdl.service");

--- a/packages/api/src/modules/grant/grant.service.ts
+++ b/packages/api/src/modules/grant/grant.service.ts
@@ -191,7 +191,7 @@ export class GrantService {
             return this.joinGrants(rawGrants);
         } catch (e) {
             // IMPROVE: returning empty array does not inform the user that we could not search for grants
-            // it does not mean that the association does not received any grants
+            // it does not mean that the association does not receive any grants
             if (e instanceof RnaOnlyError) return [] as JoinedRawGrant[];
             else throw e;
         }

--- a/packages/api/src/modules/grant/grant.service.ts
+++ b/packages/api/src/modules/grant/grant.service.ts
@@ -1,6 +1,5 @@
 import * as Sentry from "@sentry/node";
 import { CommonGrantDto, Grant, DemandeSubvention, Payment, Rna, Siret } from "dto";
-import csvStringifier = require("csv-stringify/sync");
 import { providersById } from "../providers/providers.helper";
 import { demandesSubventionsProviders, fullGrantProviders, grantProviders, paymentProviders } from "../providers";
 import DemandesSubventionsProvider from "../subventions/@types/DemandesSubventionsProvider";
@@ -22,8 +21,6 @@ import { RnaOnlyError } from "../../shared/errors/GrantError";
 import { FullGrantProvider } from "./@types/FullGrantProvider";
 import { RawGrant, JoinedRawGrant, RawFullGrant, RawApplication, RawPayment, AnyRawGrant } from "./@types/rawGrant";
 import commonGrantService from "./commonGrant.service";
-import GrantAdapter from "./grant.adapter";
-import { ExtractHeaderLabel } from "./@types/GrantToExtract";
 
 export class GrantService {
     fullGrantProvidersById: Record<string, FullGrantProvider<unknown>>;
@@ -150,19 +147,12 @@ export class GrantService {
     }
 
     // appeler adapter pour chaque join.application join.payment et join.fullGrant
-    // implementer une classe GrantAdapter pour chaque adapter de demande et de paiment
+    // implementer une classe GrantAdapter pour chaque adapter de demande et de paiement
     async getGrants(identifier: StructureIdentifiers): Promise<Grant[]> {
         const joinedRawGrants = await this.getRawGrants(identifier);
         const grants = joinedRawGrants.map(this.adaptJoinedRawGrant.bind(this)).filter(grant => grant) as Grant[];
         const sortedGrants = this.sortGrants(grants);
         return sortedGrants;
-    }
-
-    buildCsv(grants: Grant[]): string {
-        return csvStringifier.stringify(
-            grants.map(g => GrantAdapter.grantToCsv(g)),
-            { header: true, columns: ExtractHeaderLabel },
-        );
     }
 
     /**

--- a/packages/api/src/modules/grant/grant.service.ts
+++ b/packages/api/src/modules/grant/grant.service.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { CommonGrantDto, Grant, DemandeSubvention, Payment, Rna, Siret } from "dto";
+import csvStringifier = require("csv-stringify/sync");
 import { providersById } from "../providers/providers.helper";
 import { demandesSubventionsProviders, fullGrantProviders, grantProviders, paymentProviders } from "../providers";
 import DemandesSubventionsProvider from "../subventions/@types/DemandesSubventionsProvider";
@@ -21,6 +22,8 @@ import { RnaOnlyError } from "../../shared/errors/GrantError";
 import { FullGrantProvider } from "./@types/FullGrantProvider";
 import { RawGrant, JoinedRawGrant, RawFullGrant, RawApplication, RawPayment, AnyRawGrant } from "./@types/rawGrant";
 import commonGrantService from "./commonGrant.service";
+import GrantAdapter from "./grant.adapter";
+import { ExtractHeaderLabel } from "./@types/GrantToExtract";
 
 export class GrantService {
     fullGrantProvidersById: Record<string, FullGrantProvider<unknown>>;
@@ -153,6 +156,13 @@ export class GrantService {
         const grants = joinedRawGrants.map(this.adaptJoinedRawGrant.bind(this)).filter(grant => grant) as Grant[];
         const sortedGrants = this.sortGrants(grants);
         return sortedGrants;
+    }
+
+    buildCsv(grants: Grant[]): string {
+        return csvStringifier.stringify(
+            grants.map(g => GrantAdapter.grantToCsv(g)),
+            { header: true, columns: ExtractHeaderLabel },
+        );
     }
 
     /**

--- a/packages/api/src/modules/grant/grantExtract.service.test.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.test.ts
@@ -1,0 +1,154 @@
+import paymentService from "../payments/payments.service";
+import grantExtractService from "./grantExtract.service";
+import { Association, Grant, SimplifiedEtablissement } from "dto";
+import grantService from "./grant.service";
+import associationsService from "../associations/associations.service";
+import GrantAdapter from "./grant.adapter";
+import csvStringifier = require("csv-stringify/sync");
+import { ExtractHeaderLabel, GrantToExtract } from "./@types/GrantToExtract";
+
+jest.mock("./grant.service");
+jest.mock("../associations/associations.service");
+jest.mock("../payments/payments.service");
+jest.mock("./grant.adapter");
+jest.mock("csv-stringify/sync");
+
+describe("GrantExtractService", () => {
+    describe("buildCsv", () => {
+        const IDENTIFIER = "A";
+        const GRANTS = [1, 2, 3] as unknown as Grant[];
+        const ESTABS = [{ siret: [{ value: "1234567890" }] }] as unknown as SimplifiedEtablissement[];
+        const ASSO = { denomination_siren: [{ value: "NomAsso" }] } as unknown as Association;
+        const ESTABS_BY_SIRET = { 1234567890: ESTABS[0] };
+
+        let separateByExerciseSpy: jest.SpyInstance;
+
+        beforeAll(() => {
+            separateByExerciseSpy = jest.spyOn(grantExtractService, "separateByExercise").mockImplementation(v => v); // TODO mock
+            jest.mocked(grantService.getGrants).mockResolvedValue(GRANTS);
+            jest.mocked(associationsService.getAssociation).mockResolvedValue(ASSO);
+            jest.mocked(associationsService.getEstablishments).mockResolvedValue(ESTABS);
+        });
+
+        afterAll(() => {
+            separateByExerciseSpy.mockRestore();
+            jest.mocked(grantService.getGrants).mockRestore();
+            jest.mocked(associationsService.getAssociation).mockRestore();
+            jest.mocked(associationsService.getEstablishments).mockRestore();
+        });
+
+        it("gets grants", async () => {
+            await grantExtractService.buildCsv(IDENTIFIER);
+            expect(grantService.getGrants).toHaveBeenCalledWith(IDENTIFIER);
+        });
+
+        it("gets association", async () => {
+            await grantExtractService.buildCsv(IDENTIFIER); // TODO modify to handle estab identifier
+            expect(associationsService.getAssociation).toHaveBeenCalledWith(IDENTIFIER);
+        });
+
+        it("gets establishments", async () => {
+            await grantExtractService.buildCsv(IDENTIFIER); // TODO modify to handle estab identifier
+            expect(associationsService.getEstablishments).toHaveBeenCalledWith(IDENTIFIER);
+        });
+
+        it("separates grants", async () => {
+            await grantExtractService.buildCsv(IDENTIFIER);
+            expect(separateByExerciseSpy).toHaveBeenCalledWith(GRANTS);
+        });
+
+        it("calls adapter for each separated grant and gotten asso and estabsBySiret", async () => {
+            await grantExtractService.buildCsv(IDENTIFIER);
+            expect(GrantAdapter.grantToExtractLine).toHaveBeenCalledWith(1, ASSO, ESTABS_BY_SIRET);
+            expect(GrantAdapter.grantToExtractLine).toHaveBeenCalledWith(2, ASSO, ESTABS_BY_SIRET);
+            expect(GrantAdapter.grantToExtractLine).toHaveBeenCalledWith(3, ASSO, ESTABS_BY_SIRET);
+        });
+
+        it("stringifies adapted grants to csv", async () => {
+            jest.mocked(GrantAdapter.grantToExtractLine).mockReturnValueOnce("1" as unknown as GrantToExtract);
+            jest.mocked(GrantAdapter.grantToExtractLine).mockReturnValueOnce("2" as unknown as GrantToExtract);
+            jest.mocked(GrantAdapter.grantToExtractLine).mockReturnValueOnce("3" as unknown as GrantToExtract);
+            await grantExtractService.buildCsv(IDENTIFIER);
+            expect(csvStringifier.stringify).toHaveBeenCalledWith(expect.any(Array), {
+                header: true,
+                columns: ExtractHeaderLabel,
+            });
+        });
+
+        it("returns stringified csv", async () => {
+            const expected = "csv";
+            jest.mocked(csvStringifier.stringify).mockReturnValueOnce(expected);
+            const actual = (await grantExtractService.buildCsv(IDENTIFIER)).csv;
+            expect(actual).toBe(expected);
+        });
+
+        it("returns proper filename", async () => {
+            const FAKE_NOW = new Date("2022-01-01");
+            jest.useFakeTimers().setSystemTime(FAKE_NOW);
+            const expected = "DataSubvention-NomAsso-A-2022-01-01";
+            jest.mocked(csvStringifier.stringify).mockReturnValueOnce(expected);
+            const actual = (await grantExtractService.buildCsv(IDENTIFIER)).fileName;
+            expect(actual).toBe(expected);
+        });
+    });
+
+    describe("separateByExercise", () => {
+        let separateOneBy: jest.SpyInstance;
+
+        beforeAll(() => {
+            separateOneBy = jest.spyOn(grantExtractService, "separateOneByExercise").mockReturnValue([]);
+        });
+
+        afterAll(() => {
+            separateOneBy.mockRestore();
+        });
+
+        it("calls separateOneByExercise for each grant", () => {
+            grantExtractService.separateByExercise([1, 2, 3] as unknown as Grant[]);
+            expect(separateOneBy).toHaveBeenCalledTimes(3);
+        });
+
+        it("returns flattened result from separateOneByExercise", () => {
+            separateOneBy.mockReturnValueOnce([1, 2]);
+            separateOneBy.mockReturnValueOnce([3]);
+            separateOneBy.mockReturnValueOnce([4, 5]);
+            const expected = [1, 2, 3, 4, 5];
+            const actual = grantExtractService.separateByExercise([1, 2, 3] as unknown as Grant[]);
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe("separateOneByExercise", () => {
+        const APPLICATION = { id: 1, annee_demande: { value: 2022 } };
+        const PAYMENT = (annee = 2022) => ({ annee });
+        const mockGetPaymentYear = jest.fn(payment => payment.annee);
+        const DISPARATE_PAYMENTS = [PAYMENT(2022), PAYMENT(2023), PAYMENT(2022)];
+
+        beforeAll(() => {
+            jest.mocked(paymentService.getPaymentExercise).mockImplementation(mockGetPaymentYear);
+        });
+
+        it("calls getPaymentExercise for each payment", () => {
+            // @ts-expect-error -- mocked args
+            grantExtractService.separateOneByExercise({ application: null, payments: DISPARATE_PAYMENTS });
+            expect(mockGetPaymentYear).toHaveBeenCalledTimes(3);
+        });
+
+        it("separates application and payments from different years", () => {
+            const expected = [
+                {
+                    application: APPLICATION,
+                    payments: [PAYMENT(2022), PAYMENT(2022)],
+                },
+                { application: null, payments: [PAYMENT(2023)] },
+            ];
+            const actual = grantExtractService.separateOneByExercise({
+                // @ts-expect-error -- mocked args
+                application: APPLICATION,
+                // @ts-expect-error -- mocked args
+                payments: DISPARATE_PAYMENTS,
+            });
+            expect(actual).toEqual(expected);
+        });
+    });
+});

--- a/packages/api/src/modules/grant/grantExtract.service.test.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.test.ts
@@ -76,6 +76,7 @@ describe("GrantExtractService", () => {
             expect(csvStringifier.stringify).toHaveBeenCalledWith(expect.any(Array), {
                 header: true,
                 columns: ExtractHeaderLabel,
+                delimiter: ";",
             });
         });
 

--- a/packages/api/src/modules/grant/grantExtract.service.test.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.test.ts
@@ -6,12 +6,14 @@ import associationsService from "../associations/associations.service";
 import GrantAdapter from "./grant.adapter";
 import csvStringifier = require("csv-stringify/sync");
 import { ExtractHeaderLabel, GrantToExtract } from "./@types/GrantToExtract";
+import { isSiren } from "../../shared/Validators";
 
 jest.mock("./grant.service");
 jest.mock("../associations/associations.service");
 jest.mock("../payments/payments.service");
 jest.mock("./grant.adapter");
 jest.mock("csv-stringify/sync");
+jest.mock("../../shared/Validators");
 
 describe("GrantExtractService", () => {
     describe("buildCsv", () => {
@@ -28,6 +30,7 @@ describe("GrantExtractService", () => {
             jest.mocked(grantService.getGrants).mockResolvedValue(GRANTS);
             jest.mocked(associationsService.getAssociation).mockResolvedValue(ASSO);
             jest.mocked(associationsService.getEstablishments).mockResolvedValue(ESTABS);
+            jest.mocked(isSiren).mockReturnValue(true);
         });
 
         afterAll(() => {
@@ -35,6 +38,7 @@ describe("GrantExtractService", () => {
             jest.mocked(grantService.getGrants).mockRestore();
             jest.mocked(associationsService.getAssociation).mockRestore();
             jest.mocked(associationsService.getEstablishments).mockRestore();
+            jest.mocked(isSiren).mockRestore();
         });
 
         it("gets grants", async () => {

--- a/packages/api/src/modules/grant/grantExtract.service.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.ts
@@ -23,7 +23,7 @@ class GrantExtractService {
 
         return {
             csv: csvStringifier.stringify(
-                this.separateByExercise(grants).map(g => GrantAdapter.grantToCsv(g, asso, estabBySiret)),
+                this.separateByExercise(grants).map(g => GrantAdapter.grantToExtractLines(g, asso, estabBySiret)),
                 { header: true, columns: ExtractHeaderLabel },
             ),
             fileName: `DataSubvention-${assoName}-${identifier}-${new Date().toISOString().slice(0, 10)}`,

--- a/packages/api/src/modules/grant/grantExtract.service.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.ts
@@ -32,7 +32,7 @@ class GrantExtractService {
         return {
             csv: csvStringifier.stringify(
                 separatedGrants.map(g => GrantAdapter.grantToExtractLine(g, asso, estabBySiret)),
-                { header: true, columns: ExtractHeaderLabel },
+                { header: true, columns: ExtractHeaderLabel, delimiter: ";" },
             ),
             fileName: `DataSubvention-${assoName}-${identifier}-${new Date().toISOString().slice(0, 10)}`,
         };

--- a/packages/api/src/modules/grant/grantExtract.service.ts
+++ b/packages/api/src/modules/grant/grantExtract.service.ts
@@ -1,0 +1,43 @@
+import { FonjepPayment, Grant } from "dto";
+import csvStringifier = require("csv-stringify/sync");
+import GrantAdapter from "./grant.adapter";
+import { ExtractHeaderLabel } from "./@types/GrantToExtract";
+
+class GrantExtractService {
+    buildCsv(grants: Grant[]): string {
+        return csvStringifier.stringify(
+            this.separateByExercise(grants).map(g => GrantAdapter.grantToCsv(g)),
+            { header: true, columns: ExtractHeaderLabel },
+        );
+    }
+
+    separateByExercise(grants: Grant[]): Grant[] {
+        const res: Grant[] = [];
+        for (const { application, payments } of grants) {
+            const byYear: Record<number, Grant> = {};
+
+            if (application) byYear[application?.annee_demande?.value ?? "unknwown"] = { application };
+
+            let year: number;
+            for (const payment of payments ?? []) {
+                year =
+                    (payment as FonjepPayment)?.periodeDebut?.value?.getFullYear() ??
+                    payment?.dateOperation?.value?.getFullYear() ??
+                    "unknown";
+                if (!byYear[year]?.payments)
+                    byYear[year] = {
+                        application: byYear[year]?.application ?? null,
+                        payments: [payment],
+                    };
+                // @ts-expect-error -- ts doesn't see that I covered the case year byYear[year].payemnts is null but I did
+                else byYear[year].payments.push(payment);
+            }
+
+            res.push(...Object.values(byYear));
+        }
+        return res;
+    }
+}
+
+const grantExtractService = new GrantExtractService();
+export default grantExtractService;

--- a/packages/api/src/modules/payments/payments.service.test.ts
+++ b/packages/api/src/modules/payments/payments.service.test.ts
@@ -5,6 +5,8 @@ import * as IdentifierHelper from "../../shared/helpers/IdentifierHelper";
 import RnaSirenEntity from "../../entities/RnaSirenEntity";
 import rnaSirenService from "../rna-siren/rnaSiren.service";
 import paymentService from "./payments.service";
+import paymentsService from "./payments.service";
+import { Payment } from "dto";
 
 describe("PaymentsService", () => {
     const PAYMENT_KEY = "J00034";
@@ -107,6 +109,26 @@ describe("PaymentsService", () => {
             const expected = [payments[0]];
             const actual = paymentService.filterPaymentsByKey(payments, PAYMENT_KEY);
             expect(actual).toEqual(expected);
+        });
+    });
+
+    describe("getPaymentExercise", () => {
+        const FONJEP_PAYMENT = {
+            periodeDebut: { value: new Date("2021-02-02") },
+            dateOperation: { value: new Date("2023-02-02") },
+        } as unknown as Payment;
+        const PAYMENT = { dateOperation: { value: new Date("2023-02-02") } } as unknown as Payment;
+
+        it("returns year from periodeDebut if any", () => {
+            const expected = 2021;
+            const actual = paymentsService.getPaymentExercise(FONJEP_PAYMENT);
+            expect(actual).toBe(expected);
+        });
+
+        it("returns year from dateOperation", () => {
+            const expected = 2023;
+            const actual = paymentsService.getPaymentExercise(PAYMENT);
+            expect(actual).toBe(expected);
         });
     });
 });

--- a/packages/api/src/modules/payments/payments.service.ts
+++ b/packages/api/src/modules/payments/payments.service.ts
@@ -1,4 +1,4 @@
-import { Siren, Siret, Payment, DemandeSubvention } from "dto";
+import { Siren, Siret, Payment, DemandeSubvention, FonjepPayment } from "dto";
 import { paymentProviders } from "../providers";
 import { AssociationIdentifiers } from "../../@types";
 import { getIdentifierType } from "../../shared/helpers/IdentifierHelper";
@@ -38,6 +38,10 @@ export class PaymentsService {
 
     private async getPaymentsBySiren(siren: Siren) {
         return [...(await Promise.all(paymentProviders.map(p => p.getPaymentsBySiren(siren)))).flat()];
+    }
+
+    getPaymentExercise(payment: Payment) {
+        return ((payment as FonjepPayment)?.periodeDebut?.value ?? payment.dateOperation.value).getFullYear();
     }
 }
 

--- a/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.test.ts
+++ b/packages/api/src/modules/providers/demarchesSimplifiees/adapters/DemarchesSimplifieesEntityAdapter.test.ts
@@ -89,6 +89,13 @@ describe("DemarchesSimplifieesEntityAdapter", () => {
 
             expect(actual).toBe(expected);
         });
+
+        it("calls nestedToProviderValues", () => {
+            // @ts-expect-error -- private spy
+            const nestSpy = jest.spyOn(DemarchesSimplifieesEntityAdapter, "nestedToProviderValues");
+            DemarchesSimplifieesEntityAdapter.toSubvention(DEMANDE, MAPPING);
+            expect(nestSpy).toHaveBeenCalled();
+        });
     });
 
     describe("toRawGrant", () => {
@@ -178,6 +185,37 @@ describe("DemarchesSimplifieesEntityAdapter", () => {
                   "siret": "SIRET",
                 }
             `);
+        });
+    });
+
+    describe("nestedToProviderValues", () => {
+        const TO_PV = jest.fn();
+
+        it("in an array call for each element", () => {
+            const ARRAY = [0, 0, 0, 0];
+            const expected = [1, 2, 3, 4];
+            expected.forEach(v => TO_PV.mockReturnValueOnce(v));
+            // @ts-expect-error -- test private method
+            const actual = DemarchesSimplifieesEntityAdapter.nestedToProviderValues(ARRAY, TO_PV);
+            expect(actual).toEqual(expected);
+        });
+
+        it("if neither object nor array return computed providerValue", () => {
+            const VALUE = "toto";
+            const expected = 1;
+            TO_PV.mockReturnValueOnce(expected);
+            // @ts-expect-error -- test private method
+            const actual = DemarchesSimplifieesEntityAdapter.nestedToProviderValues(VALUE, TO_PV);
+            expect(actual).toEqual(expected);
+        });
+
+        it("if object, call for each attribute", () => {
+            const OBJECT = { a: 23, b: 34 };
+            const expected = { a: 1, b: 2 };
+            Object.values(expected).forEach(v => TO_PV.mockReturnValueOnce(v));
+            // @ts-expect-error -- test private method
+            const actual = DemarchesSimplifieesEntityAdapter.nestedToProviderValues(OBJECT, TO_PV);
+            expect(actual).toEqual(expected);
         });
     });
 });

--- a/packages/api/tests/interfaces/http/__snapshots__/associations.spec.ts.snap
+++ b/packages/api/tests/interfaces/http/__snapshots__/associations.spec.ts.snap
@@ -1584,6 +1584,39 @@ Object {
 }
 `;
 
+exports[`/association /{identifier}/grants/csv returns extract from rna 1`] = `
+"Nom de l'association;RNA de l'association;Adresse de l'établissement;Exercice de la demande;Siret;Code postal demandeur;Service instructeur;Dispositif;Intitulé de l'action;Montant demandé;Montant accordé;Statut de la demande;Montant versé;Centre financier du dernier paiement;Date du dernier paiement;Programme des paiements
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;XXX;Dispositif;;500;500;Accordé;1000;;2022-01-02;163 - PROGRAM 163
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2023;10000000000001;75000;Auvergne-Rhône-Alpes;Aide au projet ou au fonctionnement - Transmission culturelle (2023);Atelier d'arts plastiques et d’écriture en Hors temps scolaire ;1300;;;179920.2;UO DGER XXXX-C001;2023-07-12;multi-programmes
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;Dauphin;Education – Sport - Jeunesse - Politique de la ville;INTITULE_PROJET;;7000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;;;;;;;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2018;10000000000001;75000;Caisse des dépôts et Consignations;;\\"ETUDE \\"\\"IMPACTS DE LA TRANSITION AGRICOLE ET ALIMENTAIRE SUR L’EMPLOI\\"\\"\\";;40000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2021;10000000000001;75000;Caisse des dépôts et Consignations;;RESOLIS - ETUDE TAA 2021;;35000;Accordé;;;;
+"
+`;
+
+exports[`/association /{identifier}/grants/csv returns extract from siren 1`] = `
+"Nom de l'association;RNA de l'association;Adresse de l'établissement;Exercice de la demande;Siret;Code postal demandeur;Service instructeur;Dispositif;Intitulé de l'action;Montant demandé;Montant accordé;Statut de la demande;Montant versé;Centre financier du dernier paiement;Date du dernier paiement;Programme des paiements
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;XXX;Dispositif;;500;500;Accordé;1000;;2022-01-02;163 - PROGRAM 163
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2023;10000000000001;75000;Auvergne-Rhône-Alpes;Aide au projet ou au fonctionnement - Transmission culturelle (2023);Atelier d'arts plastiques et d’écriture en Hors temps scolaire ;1300;;;179920.2;UO DGER XXXX-C001;2023-07-12;multi-programmes
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;Dauphin;Education – Sport - Jeunesse - Politique de la ville;INTITULE_PROJET;;7000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;;;;;;;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2018;10000000000001;75000;Caisse des dépôts et Consignations;;\\"ETUDE \\"\\"IMPACTS DE LA TRANSITION AGRICOLE ET ALIMENTAIRE SUR L’EMPLOI\\"\\"\\";;40000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2021;10000000000001;75000;Caisse des dépôts et Consignations;;RESOLIS - ETUDE TAA 2021;;35000;Accordé;;;;
+"
+`;
+
+exports[`/association /{identifier}/grants/csv returns extract from siret 1`] = `
+"Nom de l'association;RNA de l'association;Adresse de l'établissement;Exercice de la demande;Siret;Code postal demandeur;Service instructeur;Dispositif;Intitulé de l'action;Montant demandé;Montant accordé;Statut de la demande;Montant versé;Centre financier du dernier paiement;Date du dernier paiement;Programme des paiements
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;XXX;Dispositif;;500;500;Accordé;1000;;2022-01-02;163 - PROGRAM 163
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2023;10000000000001;75000;Auvergne-Rhône-Alpes;Aide au projet ou au fonctionnement - Transmission culturelle (2023);Atelier d'arts plastiques et d’écriture en Hors temps scolaire ;1300;;;179920.2;UO DGER XXXX-C001;2023-07-12;multi-programmes
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;Dauphin;Education – Sport - Jeunesse - Politique de la ville;INTITULE_PROJET;;7000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2022;10000000000001;75000;;;;;;;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2018;10000000000001;75000;Caisse des dépôts et Consignations;;\\"ETUDE \\"\\"IMPACTS DE LA TRANSITION AGRICOLE ET ALIMENTAIRE SUR L’EMPLOI\\"\\"\\";;40000;Accordé;;;;
+DEFAULT_ASSOCIATION;W000000000;RUE WALDECK-ROUSSEAU 75000;2021;10000000000001;75000;Caisse des dépôts et Consignations;;RESOLIS - ETUDE TAA 2021;;35000;Accordé;;;;
+"
+`;
+
 exports[`/association /{identifier}/raw-grants should return raw grants with rna 1`] = `
 Array [
   Object {
@@ -3330,6 +3363,8 @@ Array [
             "compteAssoId": "LE_COMPTE_ASSO_ID",
             "dateCommission": "2022-01-01T00:00:00.000Z",
             "ej": "EJ00001",
+            "etablissementCodePostal": "75000",
+            "etablissementVoie": "rue Waldeck-Rousseau",
             "extractYear": 2022,
             "osirisId": "OSIRIS_ID",
           },
@@ -5695,6 +5730,8 @@ Array [
             "compteAssoId": "LE_COMPTE_ASSO_ID",
             "dateCommission": "2022-01-01T00:00:00.000Z",
             "ej": "EJ00001",
+            "etablissementCodePostal": "75000",
+            "etablissementVoie": "rue Waldeck-Rousseau",
             "extractYear": 2022,
             "osirisId": "OSIRIS_ID",
           },
@@ -6364,7 +6401,10 @@ Object {
           "last_update": "2022-01-01T00:00:00.000Z",
           "provider": "Osiris",
           "type": "object",
-          "value": Object {},
+          "value": Object {
+            "code_postal": "75000",
+            "voie": "rue Waldeck-Rousseau",
+          },
         },
         Object {
           "last_update": "2022-01-02T00:00:00.000Z",

--- a/packages/api/tests/interfaces/http/__snapshots__/associations.spec.ts.snap
+++ b/packages/api/tests/interfaces/http/__snapshots__/associations.spec.ts.snap
@@ -153,18 +153,28 @@ Object {
     },
     Object {
       "application": Object {
-        "actions_proposee": Object {
-          "last_update": "2023-07-26T08:49:43.000Z",
-          "provider": "Démarches Simplifiées",
-          "type": "object",
-          "value": Array [
-            Object {
-              "description": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
-              "intitule": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
-              "objectifs": "Projet d'atelier d'arts plastiques [...]",
+        "actions_proposee": Array [
+          Object {
+            "description": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
             },
-          ],
-        },
+            "intitule": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
+            },
+            "objectifs": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "Projet d'atelier d'arts plastiques [...]",
+            },
+          },
+        ],
         "annee_demande": Object {
           "last_update": "2023-07-26T08:49:43.000Z",
           "provider": "Démarches Simplifiées",
@@ -196,11 +206,11 @@ Object {
           "value": 1821732,
         },
         "montants": Object {
-          "last_update": "2023-07-26T08:49:43.000Z",
-          "provider": "Démarches Simplifiées",
-          "type": "object",
-          "value": Object {
-            "demande": 1300,
+          "demande": Object {
+            "last_update": "2023-07-26T08:49:43.000Z",
+            "provider": "Démarches Simplifiées",
+            "type": "number",
+            "value": 1300,
           },
         },
         "service_instructeur": Object {
@@ -935,18 +945,28 @@ Object {
     },
     Object {
       "application": Object {
-        "actions_proposee": Object {
-          "last_update": "2023-07-26T08:49:43.000Z",
-          "provider": "Démarches Simplifiées",
-          "type": "object",
-          "value": Array [
-            Object {
-              "description": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
-              "intitule": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
-              "objectifs": "Projet d'atelier d'arts plastiques [...]",
+        "actions_proposee": Array [
+          Object {
+            "description": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
             },
-          ],
-        },
+            "intitule": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
+            },
+            "objectifs": Object {
+              "last_update": "2023-07-26T08:49:43.000Z",
+              "provider": "Démarches Simplifiées",
+              "type": "string",
+              "value": "Projet d'atelier d'arts plastiques [...]",
+            },
+          },
+        ],
         "annee_demande": Object {
           "last_update": "2023-07-26T08:49:43.000Z",
           "provider": "Démarches Simplifiées",
@@ -978,11 +998,11 @@ Object {
           "value": 1821732,
         },
         "montants": Object {
-          "last_update": "2023-07-26T08:49:43.000Z",
-          "provider": "Démarches Simplifiées",
-          "type": "object",
-          "value": Object {
-            "demande": 1300,
+          "demande": Object {
+            "last_update": "2023-07-26T08:49:43.000Z",
+            "provider": "Démarches Simplifiées",
+            "type": "number",
+            "value": 1300,
           },
         },
         "service_instructeur": Object {
@@ -6621,18 +6641,28 @@ Array [
     },
   },
   Object {
-    "actions_proposee": Object {
-      "last_update": "2023-07-26T08:49:43.000Z",
-      "provider": "Démarches Simplifiées",
-      "type": "object",
-      "value": Array [
-        Object {
-          "description": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
-          "intitule": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
-          "objectifs": "Projet d'atelier d'arts plastiques [...]",
+    "actions_proposee": Array [
+      Object {
+        "description": Object {
+          "last_update": "2023-07-26T08:49:43.000Z",
+          "provider": "Démarches Simplifiées",
+          "type": "string",
+          "value": "La pratique artistique est très importante pour sensibiliser les jeunes [...]",
         },
-      ],
-    },
+        "intitule": Object {
+          "last_update": "2023-07-26T08:49:43.000Z",
+          "provider": "Démarches Simplifiées",
+          "type": "string",
+          "value": "Atelier d'arts plastiques et d’écriture en Hors temps scolaire ",
+        },
+        "objectifs": Object {
+          "last_update": "2023-07-26T08:49:43.000Z",
+          "provider": "Démarches Simplifiées",
+          "type": "string",
+          "value": "Projet d'atelier d'arts plastiques [...]",
+        },
+      },
+    ],
     "annee_demande": Object {
       "last_update": "2023-07-26T08:49:43.000Z",
       "provider": "Démarches Simplifiées",
@@ -6664,11 +6694,11 @@ Array [
       "value": 1821732,
     },
     "montants": Object {
-      "last_update": "2023-07-26T08:49:43.000Z",
-      "provider": "Démarches Simplifiées",
-      "type": "object",
-      "value": Object {
-        "demande": 1300,
+      "demande": Object {
+        "last_update": "2023-07-26T08:49:43.000Z",
+        "provider": "Démarches Simplifiées",
+        "type": "number",
+        "value": 1300,
       },
     },
     "service_instructeur": Object {

--- a/packages/api/tests/modules/providers/osiris/__fixtures__/entity.ts
+++ b/packages/api/tests/modules/providers/osiris/__fixtures__/entity.ts
@@ -11,6 +11,8 @@ export default new OsirisRequestEntity(
         amountAwarded: 0,
         dateCommission: new Date("2022-01-01"),
         extractYear: 2022,
+        etablissementVoie: "rue Waldeck-Rousseau",
+        etablissementCodePostal: "75000",
     } as IOsirisRequestInformations,
     {},
     undefined,

--- a/packages/front/src/lib/resources/associations/association.helper.ts
+++ b/packages/front/src/lib/resources/associations/association.helper.ts
@@ -11,8 +11,7 @@ export const addressToOneLineString = address => {
     const { numero, type_voie, voie, code_postal, commune } = address;
     return [numero, type_voie, voie, code_postal, commune]
         .filter(str => str)
-        .map(str => String(str))
-        .map(str => str.toUpperCase())
+        .map(str => String(str).toUpperCase())
         .join(" ");
 };
 

--- a/packages/front/src/lib/resources/associations/association.service.ts
+++ b/packages/front/src/lib/resources/associations/association.service.ts
@@ -28,8 +28,7 @@ class AssociationService {
 
     async getEstablishments(identifier) {
         const result = await associationPort.getEstablishments(identifier);
-        const establishments = result.map(etablissement => toEstablishmentComponent(etablissement));
-        return establishments;
+        return result.map(etablissement => toEstablishmentComponent(etablissement));
     }
 
     async getDocuments(identifier) {


### PR DESCRIPTION
closes #2413

### NB
- Contient aussi une modification de l'adapteur de Démarches Simplifiées pour que la position des `ProviderValue` soit plus homogène
- Le traitement est significativement plus long (#2548)

### Reste à faire
- [x] colonne établissement
    - [x] intégrer le code postal demandeur
    - [x] laisser les siret établissements
- [x] séparer les paiements de même EJ et d'exercice différents. D'autant plus que #2531 fait ajouter une colonne exercice et ce sera pénible de définir quoi faire quand c'est mélangé
- [x] appeler la route API côté front
- [x] tests
- [x] appeler depuis l'établissement


cf #2531

Il faut ajouter à l'extrait en premières colonnes:

- [x]  Colonne nom de l'association
- [x]  Colonne RNA de l'association
- [x]  Colonne SIRET de l'établissement
- [x]  Colonne adresse de l'établissement
- [x]  Colonne année d'attribution ? Différent année exercice ? On a toujours l'information ? (via chorus oui mais sinon ?)

Et modifier l'extrait pour :

- [x]  Le nom de l'association dans le nom du fichier
- [x]  La date d'extraction dans le nom du fichier
