### PR TITLE
fix(api): add samesite lax in dev mode

### DIFF
--- a/packages/api/src/interfaces/http/Authentification.http.ts
+++ b/packages/api/src/interfaces/http/Authentification.http.ts
@@ -35,6 +35,7 @@ export class AuthentificationHttp extends Controller {
         if (DEV) {
             cookieOption.domain = undefined;
             cookieOption.secure = false;
+            cookieOption.sameSite = "lax";
         }
 
         req.res?.cookie("token", user.jwt.token, cookieOption);


### PR DESCRIPTION
Problème de connexion : le cookie d'authentification n'était plus stocké / envoyé après `login` (depuis ma màj macos à priori même si pas sûr).

La ligne `sameSite = "lax"` résout le problème