### PR TITLE
fix(api): #2732 protect from path traversal ith execFileSync and sanitization

### DIFF
--- a/packages/api/src/interfaces/http/Document.http.test.ts
+++ b/packages/api/src/interfaces/http/Document.http.test.ts
@@ -59,7 +59,7 @@ describe("DocumentController", () => {
         const REQUEST: IdentifiedRequest = { user: { _id: { toString: jest.fn(() => USER_ID) } } };
 
         beforeAll(() => {
-            jest.mocked(documentsService.getRequestedDocumentsFiles).mockResolvedValue(stream as ReadStream);
+            jest.mocked(documentsService.safeGetRequestedDocumentFiles).mockResolvedValue(stream as ReadStream);
             documentController = new DocumentHttp();
             setHeaderMock = jest.spyOn(documentController, "setHeader").mockImplementation(jest.fn());
         });
@@ -72,7 +72,7 @@ describe("DocumentController", () => {
 
         it("should call service with required docs and user id as temp folder ", async () => {
             await documentController.downloadRequiredDocuments(REQUIRED_DOCS, REQUEST);
-            expect(documentsService.getRequestedDocumentsFiles).toHaveBeenCalledWith(REQUIRED_DOCS, USER_ID);
+            expect(documentsService.safeGetRequestedDocumentFiles).toHaveBeenCalledWith(REQUIRED_DOCS, USER_ID);
         });
 
         it("should return stream", async () => {

--- a/packages/api/src/interfaces/http/Document.http.ts
+++ b/packages/api/src/interfaces/http/Document.http.ts
@@ -27,7 +27,7 @@ export class DocumentHttp extends Controller {
         @Body() requiredDocs: DocumentRequestDto[],
         @Request() req: IdentifiedRequest,
     ) {
-        const stream = await documentService.getRequestedDocumentsFiles(requiredDocs, req.user._id.toString());
+        const stream = await documentService.safeGetRequestedDocumentFiles(requiredDocs, req.user._id.toString());
         this.setHeader("Content-Type", "application/zip");
         this.setHeader("Content-Disposition", "inline");
         return stream;

--- a/packages/api/src/modules/documents/documents.service.test.ts
+++ b/packages/api/src/modules/documents/documents.service.test.ts
@@ -287,19 +287,19 @@ describe("Documents Service", () => {
 
     describe("getDocumentsFilesByIdentifier", () => {
         let aggregateDocumentsSpy: jest.SpyInstance;
-        let getRequestedDocumentsFilesSpy: jest.SpyInstance;
+        let getRequestedDocumentFilesSpy: jest.SpyInstance;
         const FAKE_DOCUMENT = "FAKE_DOCUMENT";
 
         beforeAll(() => {
             // @ts-expect-error aggregateDocument is private
             aggregateDocumentsSpy = jest.spyOn(documentsService, "aggregateDocuments");
-            getRequestedDocumentsFilesSpy = jest
-                .spyOn(documentsService, "getRequestedDocumentsFiles")
+            getRequestedDocumentFilesSpy = jest
+                .spyOn(documentsService, "getRequestedDocumentFiles")
                 .mockImplementation(jest.fn());
         });
 
         afterAll(() => {
-            getRequestedDocumentsFilesSpy.mockRestore();
+            getRequestedDocumentFilesSpy.mockRestore();
         });
 
         it("should call aggregateDocuments", async () => {
@@ -326,11 +326,66 @@ describe("Documents Service", () => {
             jest.mocked(documentToDocumentRequest).mockReturnValue(ADAPTED as unknown as DocumentRequestDto);
             await documentsService.getDocumentsFilesByIdentifier(ESTABLISHMENT_ID);
             jest.mocked(documentToDocumentRequest).mockRestore();
-            expect(getRequestedDocumentsFilesSpy).toBeCalledWith([ADAPTED, ADAPTED], SIRET.value);
+            expect(getRequestedDocumentFilesSpy).toBeCalledWith([ADAPTED, ADAPTED], SIRET.value);
         });
     });
 
-    describe("getRequestedDocumentsFiles", () => {
+    describe("sanitizeDocumentRequest", () => {
+        it.each`
+            property  | character      | unsafe              | safe
+            ${"nom"}  | ${"slash"}     | ${"with/Slash"}     | ${"withSlash"}
+            ${"nom"}  | ${"backslash"} | ${"with/Backslash"} | ${"withBackslash"}
+            ${"type"} | ${"slash"}     | ${"with/Slash"}     | ${"withSlash"}
+            ${"type"} | ${"backslash"} | ${"with/Backslash"} | ${"withBackslash"}
+        `("removes $character in $property", ({ property, unsafe, safe: expected }) => {
+            // @ts-expect-error -- test private method
+            const actual = documentsService.sanitizeDocumentRequest({
+                nom: "",
+                url: "",
+                type: "",
+                [property]: unsafe,
+            });
+            expect(actual[property]).toBe(expected);
+        });
+    });
+
+    describe("safeGetRequestedDocumentFiles", () => {
+        const UNSAFE_DOCS = ["a", "b"] as any as DocumentRequestDto[];
+        const STREAM = "STREAM" as unknown as ReadStream;
+        let sanitizeSpy, getDocsSpy;
+
+        beforeAll(() => {
+            sanitizeSpy = jest
+                // @ts-expect-error -- spy private method
+                .spyOn(documentsService, "sanitizeDocumentRequest")
+                // @ts-expect-error -- harsh mock
+                .mockImplementation(s => s.toUpperCase());
+            getDocsSpy = jest.spyOn(documentsService, "getRequestedDocumentFiles").mockResolvedValue(STREAM);
+        });
+
+        afterAll(() => {
+            sanitizeSpy.mockRestore();
+            getDocsSpy.mockRestore();
+        });
+
+        it("sanitizes docs", async () => {
+            await documentsService.safeGetRequestedDocumentFiles(UNSAFE_DOCS);
+            expect(sanitizeSpy).toHaveBeenCalledTimes(2);
+        });
+
+        it("calls getRequestedDocumentFiles", async () => {
+            await documentsService.safeGetRequestedDocumentFiles(UNSAFE_DOCS);
+            expect(getDocsSpy).toHaveBeenCalledWith(["A", "B"], "docs");
+        });
+
+        it("returns result from getRequestedDocumentFiles", async () => {
+            const actual = await documentsService.safeGetRequestedDocumentFiles(UNSAFE_DOCS);
+            const expected = STREAM;
+            expect(actual).toBe(expected);
+        });
+    });
+
+    describe("getRequestedDocumentFiles", () => {
         let downloadDocumentSpy: jest.SpyInstance;
 
         const FAKE_DOCUMENT = "FAKE_DOCUMENT" as unknown as DocumentRequestDto;
@@ -358,18 +413,18 @@ describe("Documents Service", () => {
         });
 
         it("should call mkdir", async () => {
-            await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(fs.mkdirSync).toBeCalled();
         });
 
         it("should call downloadDocument", async () => {
-            await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(downloadDocumentSpy).toBeCalledWith(expect.any(String), FAKE_DOCUMENT);
         });
 
         it("should call execSync", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
-            await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(childProcess.execSync).toBeCalledWith(
                 expect.stringMatching('zip -j /tmp/12345678912345-([0-9]+).zip "/fake/path"'),
             );
@@ -377,7 +432,7 @@ describe("Documents Service", () => {
 
         it("should call rmSync", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
-            await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(fs.rmSync).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+)"), {
                 recursive: true,
                 force: true,
@@ -386,14 +441,14 @@ describe("Documents Service", () => {
 
         it("should call createReadStream and return stream", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
-            const actual = await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            const actual = await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(fs.createReadStream).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+).zip"));
             expect(actual).toBe(FAKE_STREAM);
         });
 
         it("should call remove file after end of stream", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
-            await documentsService.getRequestedDocumentsFiles(REQUESTED_DOCS, IDENTIFIER);
+            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
 
             const lastStreamOnCall = FAKE_STREAM.on.mock.lastCall;
 

--- a/packages/api/src/modules/documents/documents.service.test.ts
+++ b/packages/api/src/modules/documents/documents.service.test.ts
@@ -332,11 +332,11 @@ describe("Documents Service", () => {
 
     describe("sanitizeDocumentRequest", () => {
         it.each`
-            property  | character      | unsafe              | safe
-            ${"nom"}  | ${"slash"}     | ${"with/Slash"}     | ${"withSlash"}
-            ${"nom"}  | ${"backslash"} | ${"with/Backslash"} | ${"withBackslash"}
-            ${"type"} | ${"slash"}     | ${"with/Slash"}     | ${"withSlash"}
-            ${"type"} | ${"backslash"} | ${"with/Backslash"} | ${"withBackslash"}
+            property  | character      | unsafe                        | safe
+            ${"nom"}  | ${"slash"}     | ${"with/Character/Slash"}     | ${"withCharacterSlash"}
+            ${"nom"}  | ${"backslash"} | ${"with/Character/Backslash"} | ${"withCharacterBackslash"}
+            ${"type"} | ${"slash"}     | ${"with/Character/Slash"}     | ${"withCharacterSlash"}
+            ${"type"} | ${"backslash"} | ${"with/Character/Backslash"} | ${"withCharacterBackslash"}
         `("removes $character in $property", ({ property, unsafe, safe: expected }) => {
             // @ts-expect-error -- test private method
             const actual = documentsService.sanitizeDocumentRequest({

--- a/packages/api/src/modules/documents/documents.service.test.ts
+++ b/packages/api/src/modules/documents/documents.service.test.ts
@@ -425,9 +425,11 @@ describe("Documents Service", () => {
         it("should call execSync", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
             await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
-            expect(childProcess.execSync).toBeCalledWith(
-                expect.stringMatching('zip -j /tmp/12345678912345-([0-9]+).zip "/fake/path"'),
-            );
+            expect(childProcess.execFileSync).toBeCalledWith("zip", [
+                "j",
+                expect.stringMatching("/tmp/12345678912345-([0-9]+).zip"),
+                "/fake/path",
+            ]);
         });
 
         it("should call rmSync", async () => {

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -88,10 +88,22 @@ export class DocumentsService {
 
         if (!documents || documents.length == 0) throw new Error("No document found");
 
-        return this.getRequestedDocumentsFiles(documents.map(documentToDocumentRequest), identifier.toString());
+        return this.getRequestedDocumentFiles(documents.map(documentToDocumentRequest), identifier.toString());
     }
 
-    async getRequestedDocumentsFiles(documents: DocumentRequestDto[], baseFolderName = "docs") {
+    private sanitizeDocumentRequest(doc: DocumentRequestDto) {
+        const noPathTraversal = s => s.replace(/\/\\/, "");
+        doc.type = noPathTraversal(doc.type);
+        doc.nom = noPathTraversal(doc.nom);
+        return doc;
+    }
+
+    async safeGetRequestedDocumentFiles(unsafeDocuments: DocumentRequestDto[], baseFolderName = "docs") {
+        const documents = unsafeDocuments.map(doc => this.sanitizeDocumentRequest(doc));
+        return this.getRequestedDocumentFiles(documents, baseFolderName);
+    }
+
+    async getRequestedDocumentFiles(documents: DocumentRequestDto[], baseFolderName = "docs") {
         const folderName = `${baseFolderName}-${new Date().getTime()}`;
 
         fs.mkdirSync("/tmp/" + folderName);

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -129,9 +129,9 @@ export class DocumentsService {
         try {
             const escapeInjectCmdInName = name => name.split('"')[0];
             const readStream = await this.getDocumentStreamByLocalApiUrl(document.url);
-            const sourceFileName =
-                readStream.headers["content-disposition"]?.match(/attachment;filename="(.*)"/)?.[1] ||
-                escapeInjectCmdInName(document.nom);
+            const sourceFileName = escapeInjectCmdInName(
+                readStream.headers["content-disposition"]?.match(/attachment;filename="(.*)"/)?.[1] || document.nom,
+            );
             const extension = /\.[^/]+$/.test(sourceFileName)
                 ? ""
                 : "." + (mime.extension(readStream.headers["content-type"]) || "pdf");

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -113,8 +113,7 @@ export class DocumentsService {
         });
 
         const documentsPath = (await Promise.all(documentsPathPromises)).filter(document => document) as string[];
-        const zipCmd = `zip -j /tmp/${folderName}.zip "${documentsPath.join('" "')}"`;
-        childProcess.execSync(zipCmd);
+        childProcess.execFileSync("zip", ["j", `/tmp/${folderName}.zip`].concat(documentsPath));
         fs.rmSync("/tmp/" + folderName, { recursive: true, force: true });
         const stream = fs.createReadStream(`/tmp/${folderName}.zip`);
 

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -92,7 +92,7 @@ export class DocumentsService {
     }
 
     private sanitizeDocumentRequest(doc: DocumentRequestDto) {
-        const noPathTraversal = s => s.replace(/[/|\\]/, "");
+        const noPathTraversal = s => s.replace(/[/|\\]/g, "");
         doc.type = noPathTraversal(doc.type);
         doc.nom = noPathTraversal(doc.nom);
         return doc;

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -140,9 +140,7 @@ export class DocumentsService {
             const writeStream = readStream.pipe(fs.createWriteStream(documentPath));
             return new Promise((resolve, reject) => {
                 // finish event is same event of end but for write stream
-                writeStream.on("finish", () => {
-                    resolve(documentPath);
-                });
+                writeStream.on("finish", () => resolve(documentPath));
                 writeStream.on("error", reject);
             });
         } catch (e) {

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -92,7 +92,7 @@ export class DocumentsService {
     }
 
     private sanitizeDocumentRequest(doc: DocumentRequestDto) {
-        const noPathTraversal = s => s.replace(/\/\\/, "");
+        const noPathTraversal = s => s.replace(/[/|\\]/, "");
         doc.type = noPathTraversal(doc.type);
         doc.nom = noPathTraversal(doc.nom);
         return doc;


### PR DESCRIPTION
closes #2732 