### PR TITLE
fix(api): wrong use of execFileSync args

### DIFF
--- a/packages/api/src/modules/documents/documents.service.test.ts
+++ b/packages/api/src/modules/documents/documents.service.test.ts
@@ -422,29 +422,23 @@ describe("Documents Service", () => {
             expect(downloadDocumentSpy).toBeCalledWith(expect.any(String), FAKE_DOCUMENT);
         });
 
-        it("should call execSync", async () => {
+        it("should call execFileSync", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
             await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
             expect(childProcess.execFileSync).toBeCalledWith("zip", [
-                "j",
-                expect.stringMatching("/tmp/12345678912345-([0-9]+).zip"),
+                "-m",
+                "-j",
+                expect.stringMatching("/tmp/12345678912345-([0-9]+)/archive-12345678912345-([0-9]+).zip"),
                 "/fake/path",
             ]);
-        });
-
-        it("should call rmSync", async () => {
-            downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
-            await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
-            expect(fs.rmSync).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+)"), {
-                recursive: true,
-                force: true,
-            });
         });
 
         it("should call createReadStream and return stream", async () => {
             downloadDocumentSpy.mockResolvedValueOnce("/fake/path");
             const actual = await documentsService.getRequestedDocumentFiles(REQUESTED_DOCS, IDENTIFIER);
-            expect(fs.createReadStream).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+).zip"));
+            expect(fs.createReadStream).toBeCalledWith(
+                expect.stringMatching("/tmp/12345678912345-([0-9]+)/archive-12345678912345-([0-9]+).zip"),
+            );
             expect(actual).toBe(FAKE_STREAM);
         });
 
@@ -458,7 +452,10 @@ describe("Documents Service", () => {
 
             callbackOnLastStream();
 
-            expect(fs.rmSync).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+).zip"));
+            expect(fs.rmSync).toBeCalledWith(expect.stringMatching("/tmp/12345678912345-([0-9]+)"), {
+                force: true,
+                recursive: true,
+            });
         });
     });
 

--- a/packages/api/src/modules/documents/documents.service.ts
+++ b/packages/api/src/modules/documents/documents.service.ts
@@ -105,6 +105,7 @@ export class DocumentsService {
 
     async getRequestedDocumentFiles(documents: DocumentRequestDto[], baseFolderName = "docs") {
         const folderName = `${baseFolderName}-${new Date().getTime()}`;
+        const archiveName = `archive-${folderName}`;
 
         fs.mkdirSync("/tmp/" + folderName);
 
@@ -113,13 +114,12 @@ export class DocumentsService {
         });
 
         const documentsPath = (await Promise.all(documentsPathPromises)).filter(document => document) as string[];
-        childProcess.execFileSync("zip", ["j", `/tmp/${folderName}.zip`].concat(documentsPath));
-        fs.rmSync("/tmp/" + folderName, { recursive: true, force: true });
-        const stream = fs.createReadStream(`/tmp/${folderName}.zip`);
+        childProcess.execFileSync("zip", ["-m", "-j", `/tmp/${folderName}/${archiveName}.zip`].concat(documentsPath));
+        const stream = fs.createReadStream(`/tmp/${folderName}/${archiveName}.zip`);
 
         // end event is same event of finish but for read stream
         stream.on("end", () => {
-            fs.rmSync(`/tmp/${folderName}.zip`);
+            fs.rmSync(`/tmp/${folderName}`, { recursive: true, force: true });
         });
 
         return stream;


### PR DESCRIPTION
je laisse en draft car sur le processus de hotfix il est écris de faire d'abord le tag sur la branche si c'est ok (je sais pas si c'est à jour ni ce que ça change)