### PR TITLE
perf(front): no dsfr table is much faster and not much uglier

### DIFF
--- a/packages/front/src/routes/admin/users/composents/TableUsers.svelte
+++ b/packages/front/src/routes/admin/users/composents/TableUsers.svelte
@@ -12,8 +12,8 @@
 </script>
 
 <div class="fr-col fr-col-lg-12 fr-grid-row fr-grid-row--center">
-    <Table multiline={true}>
-        <svelte:fragment slot="head">
+    <table>
+        <thead>
             <th>Email</th>
             <th>Roles</th>
             <th>Actif</th>
@@ -23,8 +23,8 @@
             <th>Lien d'activation</th>
             <th>Date du token de reset</th>
             <th>Action</th>
-        </svelte:fragment>
-        <svelte:fragment slot="body">
+        </thead>
+        <tbody>
             {#each $users as user}
                 <tr>
                     <td>
@@ -84,11 +84,24 @@
                     </td>
                 </tr>
             {/each}
-        </svelte:fragment>
-    </Table>
+        </tbody>
+    </table>
 </div>
 
 <style>
+    table,
+    td,
+    th {
+        border: 1px solid black;
+        border-collapse: collapse;
+        background: var(--background-default-grey);
+    }
+
+    th,
+    td {
+        padding: 0.5rem;
+    }
+
     /* This is a quick fix and if needed a Tooltip component should be made */
     .tooltip-wrapper {
         position: relative;


### PR DESCRIPTION
## avant
![image](https://github.com/user-attachments/assets/a41bb2ca-8cfd-432d-91ea-0ccc317a5c9c)
![image](https://github.com/user-attachments/assets/dd7748f3-59a2-4b71-8b32-78fea67e3d52)
2min20s

## après
![image](https://github.com/user-attachments/assets/a6e03c6b-e1db-40fd-beab-ed8102627785)
![image](https://github.com/user-attachments/assets/831ff621-d08f-4b09-8934-43c7b5200b76)
20s