### PR TITLE
fix(api): put userId elsewhere to not override req

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.59.1](https://github.com/betagouv/api-subventions-asso/compare/v0.59.0...v0.59.1) (2024-12-16)
+
+### Bug Fixes
+
+-   **api:** put userId elsewhere to not override req ([99c8dbf](https://github.com/betagouv/api-subventions-asso/commit/99c8dbffa56f6ff07f0f3a99772ea59497c02733))
+
 # [0.59.0](https://github.com/betagouv/api-subventions-asso/compare/v0.58.2...v0.59.0) (2024-12-09)
 
 ### Bug Fixes

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "packages": ["packages/*"],
-    "version": "0.59.0",
+    "version": "0.59.1",
     "$schema": "node_modules/lerna/schemas/lerna-schema.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23642,7 +23642,7 @@
             }
         },
         "packages/api": {
-            "version": "0.59.0",
+            "version": "0.59.1",
             "license": "MIT",
             "dependencies": {
                 "@getbrevo/brevo": "^1.0.1",

--- a/packages/api/CHANGELOG.md
+++ b/packages/api/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.59.1](https://github.com/betagouv/api-subventions-asso/compare/v0.59.0...v0.59.1) (2024-12-16)
+
+### Bug Fixes
+
+-   **api:** put userId elsewhere to not override req ([99c8dbf](https://github.com/betagouv/api-subventions-asso/commit/99c8dbffa56f6ff07f0f3a99772ea59497c02733))
+
 # [0.59.0](https://github.com/betagouv/api-subventions-asso/compare/v0.58.2...v0.59.0) (2024-12-09)
 
 ### Features

--- a/packages/api/migrations/20241213171058-log_userId_elsewhere.js
+++ b/packages/api/migrations/20241213171058-log_userId_elsewhere.js
@@ -1,0 +1,25 @@
+module.exports = {
+    async up(db) {
+        const bulk = [];
+        const userIds = [];
+        await db
+            .collection("log")
+            .find({})
+            .forEach(log => {
+                const id = log.meta.req?.user?._id;
+                if (id == null || userIds.includes(id)) return;
+                userIds.push(log.meta.req.user._id);
+                bulk.push({
+                    updateMany: {
+                        filter: { "meta.req.user._id": id },
+                        update: { $set: { "meta.userId": id } },
+                    },
+                });
+            });
+        if (bulk.length) await db.collection("log").bulkWrite(bulk);
+    },
+
+    async down(db) {
+        await db.collection("log").updateMany({}, { $unset: { "meta.userId": 1 } });
+    },
+};

--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "api",
-    "version": "0.59.0",
+    "version": "0.59.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "api",
-            "version": "0.59.0",
+            "version": "0.59.1",
             "license": "MIT",
             "dependencies": {
                 "@getbrevo/brevo": "^1.0.1",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "api",
-    "version": "0.59.0",
+    "version": "0.59.1",
     "description": "",
     "main": "index.js",
     "engines": {

--- a/packages/api/src/dataProviders/db/stats/stats.port.ts
+++ b/packages/api/src/dataProviders/db/stats/stats.port.ts
@@ -8,8 +8,7 @@ export class StatsPort extends MongoPort<any> {
 
     async createIndexes() {
         // await this.collection.createIndex({ timestamp: -1 });
-        await this.collection.createIndex({ "meta.req.user.email": 1 });
-        await this.collection.createIndex({ "meta.req.user._id": 1 });
+        await this.collection.createIndex({ "meta.userId": 1 });
         // to handle in #1874
         // await this.collection.createIndex({ "meta.req.url": 1 });
     }

--- a/packages/api/src/middlewares/LogMiddleware.ts
+++ b/packages/api/src/middlewares/LogMiddleware.ts
@@ -36,10 +36,8 @@ export const expressLogger = () =>
         ],
         meta: true,
         dynamicMeta: function (req, res) {
-            // completes generated meta in log
-            return {
-                req: { user: { _id: (req.user as UserDto)?._id?.toString() } },
-            };
+            // completes generated meta in log, careful it overrides nested values
+            return { userId: (req.user as UserDto)?._id?.toString() };
         },
         msg: "Request: HTTP {{req.method}} {{req.url}}; ipAddress {{req.connection.remoteAddress}}",
         requestWhitelist: [

--- a/packages/api/src/modules/stats/stats.service.ts
+++ b/packages/api/src/modules/stats/stats.service.ts
@@ -311,7 +311,7 @@ class StatsService {
             if (log.meta.req?.body?.phoneNumber) delete log.meta.req.body.phoneNumber;
             if (log.meta.req?.user) {
                 // userId is needed for joins with another table, but is saved as a string because of a dependency bug
-                log.meta.req.userId = new ObjectId(log.meta.req.user._id);
+                log.meta.req.userId = new ObjectId(log.meta.userId);
                 delete log.meta.req.user;
             }
 


### PR DESCRIPTION
Les logs sont cassés depuis #2942 parce que le userId modifié fait écraser tout req
Hotfix pour perdre le moins de données possibles