### PR TITLE
feat(api): #3407 protect agentconnectid in logs

### DIFF
--- a/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
+++ b/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
@@ -1,18 +1,12 @@
 module.exports = {
     async up(db) {
-        const bulkWriteOps = [];
-
-        // delete agentConectId from all authenticated user
-        bulkWriteOps.push({
-            updateMany: {
-                filter: { "meta.req.user.email": { $exists: true } },
-                update: {
-                    $unset: { "meta.req.user.agentConnectId": "" },
-                    $set: { "meta.req.user.isAgentConnect": true },
-                },
+        // delete agentConectId from all authenticated user and never used connection attribute
+        await db.collection("log").updateMany(
+            { "meta.req.user.email": { $exists: true } },
+            {
+                $unset: { "meta.req.user.agentConnectId": "", "meta.req.connection": "" },
+                $set: { "meta.req.user.isAgentConnect": true },
             },
-        });
-        if (!bulkWriteOps.length) return;
-        await db.collection("log").bulkWrite(bulkWriteOps);
+        );
     },
 };

--- a/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
+++ b/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
@@ -1,0 +1,18 @@
+module.exports = {
+    async up(db) {
+        const bulkWriteOps = [];
+
+        // delete agentConectId from all authenticated user
+        bulkWriteOps.push({
+            updateMany: {
+                filter: { "meta.req.user.email": { $exists: true } },
+                update: {
+                    $unset: { "meta.req.user.agentConnectId": "" },
+                    $set: { "meta.req.user.isAgentConnect": true },
+                },
+            },
+        });
+        if (!bulkWriteOps.length) return;
+        await db.collection("log").bulkWrite(bulkWriteOps);
+    },
+};

--- a/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
+++ b/packages/api/migrations/20250530081428-anonymize_agentConnectId.js
@@ -9,4 +9,6 @@ module.exports = {
             },
         );
     },
+
+    async down() {},
 };

--- a/packages/api/src/middlewares/LogMiddleware.ts
+++ b/packages/api/src/middlewares/LogMiddleware.ts
@@ -48,11 +48,21 @@ export const expressLogger = () =>
         ],
         meta: true,
         dynamicMeta: function (req) {
-            if ((req.user as UserDto)?._id == null) return {};
+            if (!req.user || (req.user as UserDto)?._id == null) return {};
             // completes generated meta in log, careful it overrides nested values
             const whiteReq = {};
             requestWhitelist.map(propertyName => (whiteReq[propertyName] = req[propertyName]));
-            return { req: { ...whiteReq, user: { ...req.user, _id: (req.user as UserDto)?._id?.toString() } } };
+            const { agentConnectId, ...anonymousUser } = req.user as UserDto;
+            return {
+                req: {
+                    ...whiteReq,
+                    user: {
+                        ...anonymousUser,
+                        _id: (req.user as UserDto)?._id?.toString(),
+                        isAgentConnect: !!agentConnectId,
+                    },
+                },
+            };
         },
         msg: "Request: HTTP {{req.method}} {{req.url}}; ipAddress {{req.connection.remoteAddress}}",
         requestWhitelist,

--- a/packages/api/src/middlewares/LogMiddleware.ts
+++ b/packages/api/src/middlewares/LogMiddleware.ts
@@ -21,17 +21,7 @@ function recursiveFilter(obj: object) {
     });
 }
 
-const requestWhitelist = [
-    "url",
-    "method",
-    "httpVersion",
-    "originalUrl",
-    "query",
-    "body",
-    "user",
-    "connection",
-    "headers",
-];
+const requestWhitelist = ["url", "method", "httpVersion", "originalUrl", "query", "body", "user", "headers"];
 
 export const expressLogger = () =>
     expressWinston.logger({


### PR DESCRIPTION
closes #3407 
Je vide aussi req.connection parce que ya des infos sur l'utilisateur dedans, qu'on s'en sert jamais et que ça prend de la place