### PR TITLE
feat(api): #4029 upsert rna documents after first import

### DIFF
--- a/packages/api/src/adapters/inputs/pipeline/import/rna/rna.pipeline.test.ts
+++ b/packages/api/src/adapters/inputs/pipeline/import/rna/rna.pipeline.test.ts
@@ -33,16 +33,17 @@ describe("RNA pipeline", () => {
 
     const adapter = {
         insertMany: jest.fn().mockResolvedValue(undefined),
+        upsertMany: jest.fn().mockResolvedValue(undefined),
     } as unknown as RnaAdapter;
 
-    const logAdapter = {
+    const mockLogsAdapter = {
         getLastImportByProvider: jest.fn().mockResolvedValue(IMPORT_DATE),
-    } as unknown as DataLogPort;
+    } as unknown as jest.Mocked<DataLogPort>;
 
     let pipeline: RnaPipeline;
 
     beforeEach(() => {
-        pipeline = new RnaPipeline(parser, mapper, adapter, logAdapter);
+        pipeline = new RnaPipeline(parser, mapper, adapter, mockLogsAdapter);
     });
 
     describe("run", () => {
@@ -77,7 +78,19 @@ describe("RNA pipeline", () => {
             });
         });
 
-        it("persists dbos", async () => {
+        it("persists only data that has been updated or added", async () => {
+            await pipeline.run(FILE_PATH);
+
+            BATCHES.forEach((_dto, index) => {
+                expect(adapter.upsertMany).toHaveBeenNthCalledWith(
+                    index + 1,
+                    BATCHES[index].map(_dto => RNA_DBO),
+                );
+            });
+        });
+
+        it("persists all data", async () => {
+            mockLogsAdapter.getLastImportByProvider.mockResolvedValueOnce(null);
             await pipeline.run(FILE_PATH);
 
             BATCHES.forEach((_dto, index) => {

--- a/packages/api/src/adapters/inputs/pipeline/import/rna/rna.pipeline.ts
+++ b/packages/api/src/adapters/inputs/pipeline/import/rna/rna.pipeline.ts
@@ -28,7 +28,9 @@ export class RnaPipeline {
         const stages: (Readable | Transform | Writable)[] = [Readable.from(this.parser.parse(filePath))];
 
         const lastImportDate = await this.logPort.getLastImportByProvider("rna");
-        if (lastImportDate)
+
+        if (lastImportDate) {
+            console.log(`updating RNA Waldec since ${lastImportDate}`);
             stages.push(
                 new Transform({
                     objectMode: true,
@@ -44,6 +46,7 @@ export class RnaPipeline {
                     },
                 }),
             );
+        } else console.log("starting first RNA waldec importation");
 
         stages.push(
             new Transform({
@@ -63,7 +66,8 @@ export class RnaPipeline {
                 write: async (dbos: RnaDbo[], _enc, callback) => {
                     try {
                         if (dbos.length > 0) {
-                            await this.rnaPort.insertMany(dbos);
+                            if (lastImportDate) await this.rnaPort.upsertMany(dbos);
+                            else await this.rnaPort.insertMany(dbos);
                             report.importedCount += dbos.length;
                             console.log(`inserted ${dbos.length} new Rna documents`);
                         }

--- a/packages/api/src/adapters/outputs/db/rna/rna.adapter.ts
+++ b/packages/api/src/adapters/outputs/db/rna/rna.adapter.ts
@@ -3,6 +3,7 @@ import { RnaPort } from "./rna.port";
 import RnaDbo from "./rna.dbo";
 import { Rna } from "../../../../identifier-objects";
 import { toEntity } from "./rna.mapper";
+import { AnyBulkWriteOperation } from "mongodb";
 
 export class RnaAdapter extends MongoAdapter<RnaDbo> implements RnaPort {
     public collectionName = "rna";
@@ -14,6 +15,17 @@ export class RnaAdapter extends MongoAdapter<RnaDbo> implements RnaPort {
     async insertMany(lines: RnaDbo[]) {
         await this.collection.insertMany(lines, { ordered: false });
         return;
+    }
+
+    async upsertMany(lines: RnaDbo[]): Promise<void> {
+        const operations: AnyBulkWriteOperation<RnaDbo>[] = lines.map(line => ({
+            replaceOne: {
+                filter: { id: line.id },
+                replacement: line,
+                upsert: true,
+            },
+        }));
+        await this.collection.bulkWrite(operations, { ordered: false });
     }
 
     async getByRna(rna: Rna) {

--- a/packages/api/src/adapters/outputs/db/rna/rna.port.ts
+++ b/packages/api/src/adapters/outputs/db/rna/rna.port.ts
@@ -4,5 +4,6 @@ import RnaDbo from "./rna.dbo";
 
 export interface RnaPort {
     insertMany(lines: RnaDbo[]): Promise<void>;
+    upsertMany(lines: RnaDbo[]): Promise<void>;
     getByRna(rna: Rna): Promise<RnaEntity | null>;
 }


### PR DESCRIPTION
Close #4029 

à la base je voulais convertir le pipeline sirene etablissement en stream pour être homogène avec rna mais ce sera dans un autre ticket après discussion avec toi @sign0 pour voir si c'est assez parlant comme code pour toi et si c'est bien une architecture assez souple pour convenir à tous les cas d'usage (ou presque)